### PR TITLE
RAL_SE_Mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,9 +21,9 @@ This program is distributed in the hope that it will be useful, but without any 
 Requirements
 ============
 * Built-In Genome Assemblers (Required if SISRS is building your composite genome)
-  * Velvet (http://www.ebi.ac.uk/~zerbino/velvet/)
-  * Minia (http://minia.genouest.org/)
-  * AbySS (http://www.bcgsc.ca/platform/bioinfo/software/abyss)
+  * Velvet (tested with v.1.2.10) (http://www.ebi.ac.uk/~zerbino/velvet/)
+  * Minia (tested with v.2.0.7) (http://minia.genouest.org/)
+  * AbySS (tested with v.2.0.2) (http://www.bcgsc.ca/platform/bioinfo/software/abyss)
 * Bowtie2 (http://bowtie-bio.sourceforge.net/bowtie2/index.shtml)
 * Python 2.7, Biopython, and PySAM
 * Samtools v1.3.1 (http://www.htslib.org/)

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ SISRS: Site Identification from Short Read Sequences
 Version 1.6  
 Copyright (c) 2013-2016 Rachel Schwartz <Rachel.Schwartz@asu.edu>  
 https://github.com/rachelss/SISRS  
-More information: Schwartz, R.S., K.M Harkins, A.C. Stone, and R.A. Cartwright. 2015. A composite genome approach to identify phylogenetically informative data from next-generation sequencing. BMC Bioinformatics. 16:193. 
+More information: Schwartz, R.S., K.M Harkins, A.C. Stone, and R.A. Cartwright. 2015. A composite genome approach to identify phylogenetically informative data from next-generation sequencing. BMC Bioinformatics. 16:193.
 (http://www.biomedcentral.com/1471-2105/16/193/)
 
 Talk from Evolution 2014 describing SISRS and its application:  
@@ -20,12 +20,17 @@ This program is distributed in the hope that it will be useful, but without any 
 
 Requirements
 ============
-
-* Velvet (http://www.ebi.ac.uk/~zerbino/velvet/) OR Minia (http://minia.genouest.org/)
+* Built-In Genome Assemblers (Required if SISRS is building your composite genome)
+  * Velvet (http://www.ebi.ac.uk/~zerbino/velvet/)
+  * Minia (http://minia.genouest.org/)
+  * AbySS (http://www.bcgsc.ca/platform/bioinfo/software/abyss)
 * Bowtie2 (http://bowtie-bio.sourceforge.net/bowtie2/index.shtml)
-* Python 2.7 and Biopython
-* Samtools v1 or greater (http://www.htslib.org/)
+* Python 2.7, Biopython, and PySAM
+* Samtools v1.3.1 (http://www.htslib.org/)
 * GNU Parallel (http://www.gnu.org/software/parallel/)
+* MAFFT (http://mafft.cbrc.jp/alignment/software/)
+* BBMap [requires Java] (https://sourceforge.net/projects/bbmap/)
+
 
 Input
 =====
@@ -42,46 +47,57 @@ Usage:
 
  sisrs command options
 
-By default, SISRS assumes that
+ By default, SISRS assumes that
 
- * A reference genome is not available.
- * The K-mer size to be used by Velvet in contig assembly is 21.
- * Only one processor is available.
- * Files are in fastq format.
- * A site is only required to have data for two species to be included
-   in the final alignment.
- * Folders containing reads are in the present working directory.
- * A minimum of three reads are required to call the base at a site
-   for a taxon.
+  * A reference genome is not available and a composite assembly
+    will be assembled using Velvet
+  * The K-mer size to be used by Velvet in contig assembly is 21.
+  * Only one processor is available.
+  * Files are in fastq format.
+  * A site is only required to have data for two species to be included
+    in the final alignment.
+  * Folders containing reads are in the present working directory
+  * SISRS data will be output into the present working directory
+  * A minimum of three reads are required to call the base at a site
+    for a taxon.
 
-Commands:
+ Commands:
+  sites : produce an alignment of sites from raw reads
 
- * sites : produce an alignment of sites from raw reads
- * alignContigs : run sisrs skipping the composite genome assembly
- * mapContigs : run sisrs, also skipping alignment of reads to composite genome
- * identifyFixedSites : run sisrs, also skipping mapping of contigs to a reference
- * outputAlignment : get sisrs alignment from sites id'd for individual species
- * loci : produce a set of aligned loci based on the most variable regions of
-        the composite genome
- 
-Flags:
-    
- * -g : MANDATORY if running sisrs from the beginning - the approximate genome size
-      - this will reduce the size of the composite assembly by using a subset
-      of reads to approximate 10x coverage
- * -p : use this number of processors
- * -r : the path to the reference genome in fasta format
- * -k : k-mer size (for assembly)
- * -f : the folder containing the folders of reads
- * -n : the number of reads required to call a base at a site
- * -t : the threshold for calling a site; e.g. 0.99 means that >99% of
-      bases for that taxon must be one allele; only recommended for
-      low ploidy with <3 individuals
- * -m : the number of species that are allowed to have missing data at
-      a site
- * -o : the length of the final loci dataset for dating
- * -l : the number of alleles for sisrs loci
- * -a : assembler (velvet, minia, or abyss)
+  alignContigs : run sisrs sites skipping the composite genome assembly
+  mapContigs : run sisrs sites, also skipping alignment of reads to composite genome
+  identifyFixedSites : run sisrs sites, also skipping mapping of contigs to a reference
+  outputAlignment : run sisrs sites, also skipping determination of fixed sites calls
+  changeMissing : given alignment of sites output a file with only sites missing
+         fewer than a specified number of samples per site
+
+  loci : produce a set of aligned loci based on the most variable regions of
+         the composite genome
+
+ Flags:
+
+  -g : the approximate genome size (MANDATORY if sisrs will be assembling a
+       composite genome)
+       - Used to reduce the size of the composite assembly by using a subset
+         of total reads approximating 10x coverage
+  -p : use this number of processors
+  -r : the path to the reference genome in fasta format
+  -k : k-mer size (for assembly)
+  -f : the folder containing the folders of reads (absolute path)
+  -z : the folder where SISRS will output data (absolute path, must be empty
+       or non-existent directory)
+  -n : the number of reads required to call a base at a site
+  -t : the threshold for calling a site; e.g. 0.99 means that >99% of
+       bases for that taxon must be one allele; only recommended for
+       low ploidy with <3 individuals
+  -m : the number of species that are allowed to have missing data at
+       a site
+  -o : the length of the final loci dataset for dating
+  -l : the number of alleles
+  -a : assembler (velvet, minia, abyss, or premade)
+       -If using a premade composite genome, it must be in a folder named
+       'premadeoutput' in the same directory as the folders of read data,
+       and must be called 'contigs.fa'
 
 Output
 ======
@@ -96,20 +112,20 @@ The folder test_data contains simulated data for 10 species on the tree found in
 Sample commands
 ==============
 
-1. Basic sisrs run: start with fastq files and produce an alignment of variable sites 
+1. Basic sisrs run: start with fastq files and produce an alignment of variable sites
 
    sisrs sites -g 1745690
 
 2. Basic sisrs run with modifications
 
-   sisrs sites -g 1745690 -p 40 -m 4 -f test_data -t .99 -a minia
- 
+   sisrs sites -g 1745690 -p 40 -m 4 -f /usr/test_data -z /usr/output_data -t .99 -a minia
+
 2. Produce an alignment of loci based on the most variable loci in your basic sisrs run. Note - this command will run sisrs sites if (and only if) it was not run previously.
 
-   sisrs loci -g 1745690 -p 40 -l 2 -f .
-   
+   sisrs loci -g 1745690 -p 40 -l 2 -f /usr/previous_SISRS_run
+
 3. Get loci from your fastq files given known loci.
 
    first name your reference loci ref_genes.fa and put in your main folder
-   
-   sisrs loci -p 40 -f test_data
+
+   sisrs loci -p 40 -f /usr/test_data

--- a/README.md
+++ b/README.md
@@ -84,8 +84,8 @@ Usage:
   -r : the path to the reference genome in fasta format
   -k : k-mer size (for assembly)
   -f : the folder containing the folders of reads (absolute path)
-  -z : the folder where SISRS will output data (absolute path, must be empty
-       or non-existent directory)
+  -z : the folder where SISRS will output data (Default: -f, othewise must be
+       absolute path of empty or non-existent directory))
   -n : the number of reads required to call a base at a site
   -t : the threshold for calling a site; e.g. 0.99 means that >99% of
        bases for that taxon must be one allele; only recommended for

--- a/bin/sisrs
+++ b/bin/sisrs
@@ -151,7 +151,7 @@ elif [[ $ASSEMBLER == "abyss" ]]; then
     [ $? -eq 0 ] || { echo "Abyss must be installed to run SISRS. The installation folder must be in your path. Abyss is called as 'ABYSS'.    Aborting."; exit 1; }
     CONTIGS=abyssoutput
 elif [[ $ASSEMBLER == "premade" ]]; then
-    CONTIGS=premade
+    CONTIGS=premadeoutput
 else
     echo "You must specify the assembler as velvet, minia, abyss, or point sisrs to a directory (-c) which contains a preassembled composite genome called 'contigs.fa'. If you do not specify an assembler SISRS will use velvet as the default.  Aborting."; exit 1;
 fi
@@ -221,7 +221,10 @@ fi
 if [ -z "$MISSING" ]; then MISSING=$((${#FOLDERLISTA[@]} - 2)); fi    #minimum of data for 2 species unless otherwise specified
 
 ##############################
-if [[ $ASSEMBLER != "premade" ]];then
+if [[ $ASSEMBLER == "premade" ]];then
+    subSample(){echo "No subsampling necessary, using pre-assembled composite genome in ${CONTIGS}, continuing..."}
+    buildContigs(){echo "No contig building necessary, using pre-assembled composite genome in ${CONTIGS}, continuing..."}
+else
     subSample(){
         if [ -z $GENOMESIZE ]; then
             echo "You must enter the approximate size of the genome / transcriptome. For more information run sisrs -h"

--- a/bin/sisrs
+++ b/bin/sisrs
@@ -160,8 +160,12 @@ which bowtie2 &>/dev/null
 which parallel &>/dev/null
 [ $? -eq 0 ] || { echo "GNU parallel must be installed to run SISRS. The installation folder must be in your path. Aborting."; exit 1; }
 which samtools &>/dev/null
-[ $? -eq 0 ] || { echo "Samtools v1 or greater must be installed to run SISRS. The installation folder must be in your path. Aborting."; exit 1; }
-[[ $(samtools --version-only| cut -c1) -ge 1 ]] || { echo "Samtools v1 or greater must be installed to run SISRS. The installation folder must be in your path. Aborting."; exit 1; }
+[ $? -eq 0 ] || { echo "Samtools v1.3.1 must be installed to run SISRS. The installation folder must be in your path. Aborting."; exit 1; }
+[[ $(samtools --version-only| cut -c1-5) == "1.3.1" ]] || { echo "Samtools v1.3.1 must be installed to run SISRS. The installation folder must be in your path. Aborting."; exit 1; }
+which rename.sh &>/dev/null
+[ $? -eq 0 ] || { echo "BBMap must be installed to run SISRS. The installation folder must be in your path. Aborting."; exit 1; }
+which mafft &>/dev/null
+[ $? -eq 0 ] || { echo "MAFFT must be installed to run SISRS. The installation folder must be in your path. Aborting."; exit 1; }
 
 function join_by { local IFS="$1"; shift; echo "$*"; }
 

--- a/bin/sisrs
+++ b/bin/sisrs
@@ -341,7 +341,7 @@ mapContigs(){
 identifyFixedSites(){
     samtools faidx ${OUTFOLDER}/${CONTIGS}/contigs.fa
 
-    parallel --jobs "${PROCESSORS}" 'samtools mpileup -f' "${OUTFOLDER}"/"${CONTIGS}"/contigs.fa "$( echo {}/$(basename {} ) )".bam > "echo $( echo {}/$(basename {} ) )".pileups ::: "${FOLDERLISTA[@]}" "${FOLDERLISTA[@]}" "${FOLDERLISTA[@]}" "${FOLDERLISTA[@]}"
+    parallel --jobs "${PROCESSORS}" 'samtools mpileup -f' "${OUTFOLDER}"/"${CONTIGS}"/contigs.fa '"$( echo {}/$(basename {} ) )".bam' > '"$( echo {}/$(basename {} ) )".pileups' ::: "${FOLDERLISTA[@]}" "${FOLDERLISTA[@]}" "${FOLDERLISTA[@]}" "${FOLDERLISTA[@]}"
     parallel --jobs "${PROCESSORS}" "${DIR}/libexec/sisrs/specific_genome.py {} ${OUTFOLDER}/${CONTIGS}/contigs.fa" ::: "${FOLDERLISTA[@]}"
 
     if [[ $? != 0 ]]; then

--- a/bin/sisrs
+++ b/bin/sisrs
@@ -222,9 +222,15 @@ if [ -z "$MISSING" ]; then MISSING=$((${#FOLDERLISTA[@]} - 2)); fi    #minimum o
 
 ##############################
 if [[ $ASSEMBLER == "premade" ]];then
-    subSample(){ echo "No subsampling necessary, using pre-assembled composite genome in ${CONTIGS}, continuing..." }
-    buildContigs(){ echo "No contig building necessary, using pre-assembled composite genome in ${CONTIGS}, continuing..." }
-else
+    subSample(){
+       echo "No subsampling necessary, using pre-assembled composite genome in ${CONTIGS}, continuing..."
+    }
+    buildContigs(){
+      echo "No contig building necessary, using pre-assembled composite genome in ${CONTIGS}, continuing..."
+    }
+fi
+
+if [[ $ASSEMBLER!="premade" ]];then
     subSample(){
         if [ -z $GENOMESIZE ]; then
             echo "You must enter the approximate size of the genome / transcriptome. For more information run sisrs -h"

--- a/bin/sisrs
+++ b/bin/sisrs
@@ -221,7 +221,7 @@ fi
 if [ -z "$MISSING" ]; then MISSING=$((${#FOLDERLISTA[@]} - 2)); fi    #minimum of data for 2 species unless otherwise specified
 
 ##############################
-if [[$ASSEMBLER != "premade"]];then
+if [[ $ASSEMBLER != "premade" ]];then
     subSample(){
         if [ -z $GENOMESIZE ]; then
             echo "You must enter the approximate size of the genome / transcriptome. For more information run sisrs -h"

--- a/bin/sisrs
+++ b/bin/sisrs
@@ -341,7 +341,7 @@ mapContigs(){
 identifyFixedSites(){
     samtools faidx ${OUTFOLDER}/${CONTIGS}/contigs.fa
 
-    parallel --jobs "${PROCESSORS}" 'samtools mpileup -f ${OUTFOLDER}/${CONTIGS}/contigs.fa "$( echo {}/$(basename {} ) )".bam ">" "$( echo {}/$(basename {} ) )".pileups' ::: "${FOLDERLISTA[@]}"
+    parallel --jobs "${PROCESSORS}" 'samtools mpileup -f '${OUTFOLDER}'/'${CONTIGS}'/contigs.fa "$( echo {}/$(basename {} ) )".bam ">" "$( echo {}/$(basename {} ) )".pileups' ::: "${FOLDERLISTA[@]}"
     parallel --jobs "${PROCESSORS}" "${DIR}/libexec/sisrs/specific_genome.py {} ${OUTFOLDER}/${CONTIGS}/contigs.fa" ::: "${FOLDERLISTA[@]}"
 
     if [[ $? != 0 ]]; then

--- a/bin/sisrs
+++ b/bin/sisrs
@@ -57,8 +57,8 @@ Flags:
  -r : the path to the reference genome in fasta format
  -k : k-mer size (for assembly)
  -f : the folder containing the folders of reads (absolute path)
- -z : the folder where SISRS will output data (absolute path, must be empty
-      or non-existent directory)
+ -z : the folder where SISRS will output data (Default: -f, othewise must be
+      absolute path of empty or non-existent directory)
  -n : the number of reads required to call a base at a site
  -t : the threshold for calling a site; e.g. 0.99 means that >99% of
       bases for that taxon must be one allele; only recommended for

--- a/bin/sisrs
+++ b/bin/sisrs
@@ -4,6 +4,7 @@
 
 #run with non-defaults: ./sisrs -r ./reference.fasta -p 40 -f fastq -m 4 -a ./fastq_data/
 #for paired reads the filename should contain either _R1 or _R2
+#This fork/branch treats all reads as single-ended for mapping purposes, and only keeps uniquely mapping reads
 
 VERSION=1.6
 
@@ -21,36 +22,43 @@ Usage:
 
 By default, SISRS assumes that
 
- * A reference genome is not available.
+ * A reference genome is not available and a composite assembly
+   will be assembled using Velvet
  * The K-mer size to be used by Velvet in contig assembly is 21.
  * Only one processor is available.
  * Files are in fastq format.
  * A site is only required to have data for two species to be included
    in the final alignment.
- * Folders containing reads are in the present working directory.
+ * Folders containing reads are in the present working directory
+ * SISRS data will be output into the present working directory
  * A minimum of three reads are required to call the base at a site
    for a taxon.
 
 Commands:
  sites : produce an alignment of sites from raw reads
+
  alignContigs : run sisrs sites skipping the composite genome assembly
  mapContigs : run sisrs sites, also skipping alignment of reads to composite genome
  identifyFixedSites : run sisrs sites, also skipping mapping of contigs to a reference
  outputAlignment : run sisrs sites, also skipping determination of fixed sites calls
  changeMissing : given alignment of sites output a file with only sites missing
         fewer than a specified number of samples per site
+
  loci : produce a set of aligned loci based on the most variable regions of
         the composite genome
 
 Flags:
 
- -g : MANDATORY if running sisrs from the beginning - the approximate genome size
-      - this will reduce the size of the composite assembly by using a subset
-      of reads to approximate 10x coverage
+ -g : the approximate genome size (MANDATORY if sisrs will be assembling a
+      composite genome)
+      - Used to reduce the size of the composite assembly by using a subset
+        of total reads approximating 10x coverage
  -p : use this number of processors
  -r : the path to the reference genome in fasta format
  -k : k-mer size (for assembly)
- -f : the folder containing the folders of reads
+ -f : the folder containing the folders of reads (absolute path)
+ -z : the folder where SISRS will output data (absolute path, must be empty
+      or non-existent directory)
  -n : the number of reads required to call a base at a site
  -t : the threshold for calling a site; e.g. 0.99 means that >99% of
       bases for that taxon must be one allele; only recommended for
@@ -59,13 +67,17 @@ Flags:
       a site
  -o : the length of the final loci dataset for dating
  -l : the number of alleles
- -a : assembler (velvet, minia, or abyss)
+ -a : assembler (velvet, minia, abyss, or premade)
+      -If using a premade composite genome, it must be in a folder named
+      'premade' in the same directory as the folders of read data, and
+      must be called 'contigs.fa'
 
  Example command:
- sisrs sites -g 1745690 -p 40 -m 4 -f test_data
+ sisrs sites -g 1745690 -p 40 -m 4 -f /usr/test_data
+ sisrs sites -g 1745690 -p 40 -m 4 -f /usr/test_data -z /usr/SISRS_Output_test_data
 
  Example command:
- sisrs loci -g 1745690 -p 40 -m 4 -f test_data
+ sisrs loci -g 1745690 -p 40 -m 4 -f /usr/test_data
 
 ENDLINE
 }
@@ -74,7 +86,8 @@ ENDLINE
 KMER=21
 MINREAD=3
 PROCESSORS=1
-MAINFOLDER=.
+MAINFOLDER=$( echo "$(pwd)")
+OUTFOLDER=$( echo "$(pwd)")
 THRESHOLD=1
 ALLELES=1
 DEBUG=0
@@ -90,7 +103,7 @@ fi
 
 OPTIND=2 # tells getopts to start parsing at the second argument
 
-while getopts g:r:k:p:m:a:f:n:t:o:l:hd option
+while getopts g:r:k:p:m:a:f:z:n:t:o:l:hd option
 do
     case "${option}"
 	in
@@ -100,11 +113,12 @@ do
 	p) PROCESSORS=${OPTARG};;
 	m) MISSING=${OPTARG};;
 	f) MAINFOLDER=${OPTARG};;
-        a) ASSEMBLER=${OPTARG};;
+  z) OUTFOLDER=${OPTARG};;
+  a) ASSEMBLER=${OPTARG};;
 	n) MINREAD=${OPTARG};;
 	t) THRESHOLD=${OPTARG};;
-        o) OUTLENGTH=${OPTARG};;
-        l) ALLELES=${OPTARG};;
+  o) OUTLENGTH=${OPTARG};;
+  l) ALLELES=${OPTARG};;
 	d) DEBUG=1;;
 	h) help; exit;;
 	\? ) echo "Unknown option" >&2; exit 1;;
@@ -136,8 +150,10 @@ elif [[ $ASSEMBLER == "abyss" ]]; then
     which ABYSS &>/dev/null
     [ $? -eq 0 ] || { echo "Abyss must be installed to run SISRS. The installation folder must be in your path. Abyss is called as 'ABYSS'.    Aborting."; exit 1; }
     CONTIGS=abyssoutput
+elif [[ $ASSEMBLER == "premade" ]]; then
+    CONTIGS=premade
 else
-    echo "You must specify the assembler as velvet, minia, or abyss. If you do not specify an assembler SISRS will use velvet as the default.  Aborting."; exit 1;
+    echo "You must specify the assembler as velvet, minia, abyss, or point sisrs to a directory (-c) which contains a preassembled composite genome called 'contigs.fa'. If you do not specify an assembler SISRS will use velvet as the default.  Aborting."; exit 1;
 fi
 
 which bowtie2 &>/dev/null
@@ -148,13 +164,36 @@ which samtools &>/dev/null
 [ $? -eq 0 ] || { echo "Samtools v1 or greater must be installed to run SISRS. The installation folder must be in your path. Aborting."; exit 1; }
 [[ $(samtools --version-only| cut -c1) -ge 1 ]] || { echo "Samtools v1 or greater must be installed to run SISRS. The installation folder must be in your path. Aborting."; exit 1; }
 
+###########Link Outfolder##############
+
+if [[ "${MAINFOLDER}" = "${OUTFOLDER}" ]]; then     #Check if data folder and output folder are the same
+    echo "Note: SISRS writing into data folder"
+    OUTFOLDER="${MAINFOLDER}"
+
+elif [[ "${CMD}" = "alignContigs" ]] || [[ "${CMD}" = "mapContigs" ]] || [[ "${CMD}" = "identifyFixedSites" ]] || [[ "${CMD}" = "outputAlignment" ]] || [[ "${CMD}" = "changeMissing" ]]; then
+    echo "For ${CMD}, data folder (-f) and output folder (-z) must be the same. Aborting."
+    exit 1
+
+elif [[ ! -d "${OUTFOLDER}" ]]; then
+    cp -as "${MAINFOLDER}" "${OUTFOLDER}"     #Create output directory with links to data files if directory does not already exist
+
+else
+    echo "${OUTFOLDER} already exists. Checking if empty..."
+    if [[ "$(ls -A ${OUTFOLDER})" ]]; then  #Check if specified output directory is empty
+        echo "Specified output directory (${OUTFOLDER}) exists but is not empty. Aborting."
+        exit 1
+    else
+        echo "${OUTFOLDER} exists and is empty. SISRS continuing..."
+        cp -as "${MAINFOLDER}/"* "${OUTFOLDER}"   #Populate exisiting empty output directory with links to data files
+    fi
+fi
 
 ###########actions##############
 
-FILELISTA=( $( find "${MAINFOLDER}" -name "*fastq" ) )
+FILELISTA=( $( find "${OUTFOLDER}" -name "*fastq" ) )
 
 #get paired fastq
-FILELIST=( $( find "${MAINFOLDER}" -name *${FILEID}*fastq ) )     #all fastq file paths as array
+FILELIST=( $( find "${OUTFOLDER}" -name *${FILEID}*fastq ) )     #all fastq file paths as array
 if [[ ${#FILELIST[@]} -gt 0 ]]; then
     declare -a ALLFOLDERLIST=()
     for F in "${FILELIST[@]}"; do ALLFOLDERLIST+=("$( dirname "${F}" )"); done       #array of directories containing fastq files
@@ -182,92 +221,93 @@ fi
 if [ -z "$MISSING" ]; then MISSING=$((${#FOLDERLISTA[@]} - 2)); fi    #minimum of data for 2 species unless otherwise specified
 
 ##############################
-
-subSample(){
-    if [ -z $GENOMESIZE ]; then
-        echo "You must enter the approximate size of the genome / transcriptome. For more information run sisrs -h"
-        exit 1
-    fi
-
-    echo "Subsampling data"
-    if [[ -e "${MAINFOLDER}"/subsamples ]]; then rm -r "${MAINFOLDER}"/subsamples; fi
-    NUMER=$((10*${GENOMESIZE}))
-    DENOM=$((100*2*${#FOLDERLISTA[@]}))      #assumes 100bp reads - add option in future
-    LEFTREADS=$((${NUMER}/${DENOM}))
-    mkdir ${MAINFOLDER}/subsamples
-    parallel --jobs "${PROCESSORS}" "${DIR}/libexec/sisrs/sub_sample_for_velvet_unshuff.py ${LEFTREADS} {} ${FILEID} ${FILEID2}" ::: "${FOLDERLISTA[@]}"   #subsample data and shuffle
-
-    if [[ $? != 0 ]]; then
-        echo "Subsampling failed"
-        exit 1
-    fi
-}
-
-buildContigs(){
-    if [[ -e "${MAINFOLDER}"/"${CONTIGS}" ]]; then rm -r ${MAINFOLDER}/${CONTIGS}; fi
-    if [[ $ASSEMBLER == "velvet" ]]; then
-        #make reference contigs - velveth
-        if [ -n "${REFFILE}" ]; then
-            if [[ ${#FILELISTU[@]} -gt 0 ]]; then
-                if [[ ${#FILELIST[@]} -gt 0 ]]; then
-                    echo "Running Velvet with PE and SE reads, and reference"
-                    velveth ${MAINFOLDER}/velvetoutput ${KMER} -create_binary -fasta -reference ${REFFILE} -fastq -shortPaired ${MAINFOLDER}/subsamples/*subsampledp.fastq -short ${MAINFOLDER}/subsamples/*subsampledu.fastq
-                else
-                    echo "Running Velvet with SE reads and reference"
-                    velveth ${MAINFOLDER}/velvetoutput ${KMER} -create_binary -fasta -reference ${REFFILE} -fastq -short ${MAINFOLDER}/subsamples/*subsampledu.fastq
-                fi
-            else
-                echo "Running Velvet with PE reads and reference"
-                velveth ${MAINFOLDER}/velvetoutput ${KMER} -create_binary -fasta -reference ${REFFILE} -fastq -shortPaired ${MAINFOLDER}/subsamples/*subsampledp.fastq
-            fi
-        else
-            if [[ ${#FILELISTU[@]} -gt 0 ]]; then
-                if [[ ${#FILELIST[@]} -gt 0 ]]; then
-                    echo "Running Velvet with PE and SE reads"
-                    velveth ${MAINFOLDER}/velvetoutput ${KMER} -create_binary -fastq -shortPaired ${MAINFOLDER}/subsamples/*subsampledp.fastq -short ${MAINFOLDER}/subsamples/*subsampledu.fastq
-                else
-                    echo "Running Velvet with SE reads"
-                    velveth ${MAINFOLDER}/velvetoutput ${KMER} -create_binary -fastq -short ${MAINFOLDER}/subsamples/*subsampledu.fastq
-                fi
-            else
-                echo "Running Velvet with PE reads"
-                velveth ${MAINFOLDER}/velvetoutput ${KMER} -create_binary -fastq -shortPaired ${MAINFOLDER}/subsamples/*subsampledp.fastq
-            fi
+if [[$ASSEMBLER != "premade"]];then
+    subSample(){
+        if [ -z $GENOMESIZE ]; then
+            echo "You must enter the approximate size of the genome / transcriptome. For more information run sisrs -h"
+            exit 1
         fi
-        echo ==== Velveth is finished ====
 
-        velvetg ${MAINFOLDER}/velvetoutput -exp_cov auto -cov_cutoff auto# -min_contig_lgth 100     #run velvet - output contigs
-        echo ==== Velvetg is finished ===
-    fi
+        echo "Subsampling data"
+        if [[ -e "${OUTFOLDER}"/subsamples ]]; then rm -r "${OUTFOLDER}"/subsamples; fi
+        NUMER=$((10*${GENOMESIZE}))
+        DENOM=$((100*2*${#FOLDERLISTA[@]}))      #assumes 100bp reads - add option in future
+        LEFTREADS=$((${NUMER}/${DENOM}))
+        mkdir ${OUTFOLDER}/subsamples
+        parallel --jobs "${PROCESSORS}" "${DIR}/libexec/sisrs/sub_sample_for_velvet_unshuff.py ${LEFTREADS} {} ${FILEID} ${FILEID2}" ::: "${FOLDERLISTA[@]}"   #subsample data and shuffle
 
-    if [[ $ASSEMBLER == "minia" ]]; then
-        mkdir ${MAINFOLDER}/miniaoutput
-        ls ${MAINFOLDER}/subsamples/*fastq | parallel -j ${PROCESSORS} basename > ${MAINFOLDER}/subsamples/minia_read_file.txt
-        minia -in ${MAINFOLDER}/subsamples/minia_read_file.txt -kmer-size ${KMER} -nb-cores "${PROCESSORS}" -out ${MAINFOLDER}/miniaoutput/
-        mv ${MAINFOLDER}/miniaoutput/.contigs.fa ${MAINFOLDER}/miniaoutput/contigs.fa
-    fi
+        if [[ $? != 0 ]]; then
+            echo "Subsampling failed"
+            exit 1
+        fi
+    }
 
-    if [[ $ASSEMBLER == "ABYSS" ]]; then
-        mkdir ${MAINFOLDER}/abyssoutput
-        ABYSS -k ${KMER} -o ${MAINFOLDER}/abyssoutput/contigs.fa ${MAINFOLDER}/subsamples/*fastq
-    fi
-}
+    buildContigs(){
+        if [[ -e "${OUTFOLDER}"/"${CONTIGS}" ]]; then rm -r ${OUTFOLDER}/${CONTIGS}; fi
+        if [[ $ASSEMBLER == "velvet" ]]; then
+            #make reference contigs - velveth
+            if [ -n "${REFFILE}" ]; then
+                if [[ ${#FILELISTU[@]} -gt 0 ]]; then
+                    if [[ ${#FILELIST[@]} -gt 0 ]]; then
+                        echo "Running Velvet with PE and SE reads, and reference"
+                        velveth ${OUTFOLDER}/velvetoutput ${KMER} -create_binary -fasta -reference ${REFFILE} -fastq -shortPaired ${OUTFOLDER}/subsamples/*subsampledp.fastq -short ${OUTFOLDER}/subsamples/*subsampledu.fastq
+                    else
+                        echo "Running Velvet with SE reads and reference"
+                        velveth ${OUTFOLDER}/velvetoutput ${KMER} -create_binary -fasta -reference ${REFFILE} -fastq -short ${OUTFOLDER}/subsamples/*subsampledu.fastq
+                    fi
+                else
+                    echo "Running Velvet with PE reads and reference"
+                    velveth ${OUTFOLDER}/velvetoutput ${KMER} -create_binary -fasta -reference ${REFFILE} -fastq -shortPaired ${OUTFOLDER}/subsamples/*subsampledp.fastq
+                fi
+            else
+                if [[ ${#FILELISTU[@]} -gt 0 ]]; then
+                    if [[ ${#FILELIST[@]} -gt 0 ]]; then
+                        echo "Running Velvet with PE and SE reads"
+                        velveth ${OUTFOLDER}/velvetoutput ${KMER} -create_binary -fastq -shortPaired ${OUTFOLDER}/subsamples/*subsampledp.fastq -short ${OUTFOLDER}/subsamples/*subsampledu.fastq
+                    else
+                        echo "Running Velvet with SE reads"
+                        velveth ${OUTFOLDER}/velvetoutput ${KMER} -create_binary -fastq -short ${OUTFOLDER}/subsamples/*subsampledu.fastq
+                    fi
+                else
+                    echo "Running Velvet with PE reads"
+                    velveth ${OUTFOLDER}/velvetoutput ${KMER} -create_binary -fastq -shortPaired ${OUTFOLDER}/subsamples/*subsampledp.fastq
+                fi
+            fi
+            echo ==== Velveth is finished ====
+
+            velvetg ${OUTFOLDER}/velvetoutput -exp_cov auto -cov_cutoff auto# -min_contig_lgth 100     #run velvet - output contigs
+            echo ==== Velvetg is finished ===
+        fi
+
+        if [[ $ASSEMBLER == "minia" ]]; then
+            mkdir ${OUTFOLDER}/miniaoutput
+            ls ${OUTFOLDER}/subsamples/*fastq | parallel -j ${PROCESSORS} basename > ${OUTFOLDER}/subsamples/minia_read_file.txt
+            minia -in ${OUTFOLDER}/subsamples/minia_read_file.txt -kmer-size ${KMER} -nb-cores "${PROCESSORS}" -out ${OUTFOLDER}/miniaoutput/
+            mv ${OUTFOLDER}/miniaoutput/.contigs.fa ${OUTFOLDER}/miniaoutput/contigs.fa
+        fi
+
+        if [[ $ASSEMBLER == "ABYSS" ]]; then
+            mkdir ${OUTFOLDER}/abyssoutput
+            ABYSS -k ${KMER} -o ${OUTFOLDER}/abyssoutput/contigs.fa ${OUTFOLDER}/subsamples/*fastq
+        fi
+    }
+fi
 
 alignContigs(){
-    bowtie2-build ${MAINFOLDER}/"${CONTIGS}"/contigs.fa ${MAINFOLDER}/"${CONTIGS}"/contigs      #index contigs
+    bowtie2-build ${OUTFOLDER}/"${CONTIGS}"/contigs.fa ${OUTFOLDER}/"${CONTIGS}"/contigs      #index contigs
 
     #align reads to contigs
     for FILE in "${FILELIST[@]}"; do
         NAME=$( echo ${FILE} | sed s/${FILEID}// | sed 's/\.[^.]*$//' ) #includes folder but not the read or the extension
         echo ==== Aligning FILELIST ${NAME}  ====
         #N=1 allows a mismatch #x The basename of the index for the reference genome
-        bowtie2 -p "${PROCESSORS}" -N 1 --local -x ${MAINFOLDER}/"${CONTIGS}"/contigs -1 ${FILE} -2 $( echo ${FILE}|sed s/${FILEID}/${FILEID2}/ ) > >(tee ${NAME}_stdout.log) 2> >(tee ${NAME}_stderr.log >&2) | samtools view -Su -@ "${PROCESSORS}" -F 4 - | samtools sort -@ "${PROCESSORS}" - -o ${NAME}.bam
+        bowtie2 -p "${PROCESSORS}" -N 1 --local -x ${OUTFOLDER}/"${CONTIGS}"/contigs -1 ${FILE} -2 $( echo ${FILE}|sed s/${FILEID}/${FILEID2}/ ) > >(tee ${NAME}_stdout.log) 2> >(tee ${NAME}_stderr.log >&2) | samtools view -Su -@ "${PROCESSORS}" -F 4 - | samtools sort -@ "${PROCESSORS}" - -o ${NAME}.bam
     done
     for FILE in "${FILELISTU[@]}"; do
         NAME=$( echo ${FILE} | sed 's/\.[^.]*$//' ) #includes folder but not the read or the extension
         echo ==== Aligning FILELISTU ${NAME} ====
         #N=1 allows a mismatch #x The basename of the index for the reference genome
-        bowtie2 -p "${PROCESSORS}" -N 1 --local -x ${MAINFOLDER}/"${CONTIGS}"/contigs -U ${FILE} > >(tee ${NAME}_stdout.log) 2> >(tee ${NAME}_stderr.log >&2) | samtools view -Su -@ "${PROCESSORS}" -F 4 - | samtools sort -@ "${PROCESSORS}" - -o ${NAME}.bam
+        bowtie2 -p "${PROCESSORS}" -N 1 --local -x ${OUTFOLDER}/"${CONTIGS}"/contigs -U ${FILE} > >(tee ${NAME}_stdout.log) 2> >(tee ${NAME}_stderr.log >&2) | samtools view -Su -@ "${PROCESSORS}" -F 4 - | samtools sort -@ "${PROCESSORS}" - -o ${NAME}.bam
     done
     echo ==== Done Aligning ====
 }
@@ -281,16 +321,16 @@ mapContigs(){
     if [ -n "${REFFILE}" ]; then
         NAME=$( echo ${REFFILE} | sed 's/\.[^.]*$//' )
         bowtie2-build ${REFFILE} ${NAME}        #bowtie2-build [options]* <reference_in> <bt2_base>
-        bowtie2 -p ${PROCESSORS} -N 1 -x ${NAME} -f -U ${MAINFOLDER}/"${CONTIGS}"/contigs.fa > >(tee ${NAME}_stdout.log) 2> >(tee ${NAME}_stderr.log >&2) -S ${MAINFOLDER}/"${CONTIGS}"/align_contigs.sam    #bowtie2 -x <ref_base> -U <fq files> -S <output sam>
+        bowtie2 -p ${PROCESSORS} -N 1 -x ${NAME} -f -U ${OUTFOLDER}/"${CONTIGS}"/contigs.fa > >(tee ${NAME}_stdout.log) 2> >(tee ${NAME}_stderr.log >&2) -S ${OUTFOLDER}/"${CONTIGS}"/align_contigs.sam    #bowtie2 -x <ref_base> -U <fq files> -S <output sam>
 	echo ==== Done Mapping Contigs ====
     fi
 }
 
 identifyFixedSites(){
-    samtools faidx ${MAINFOLDER}/${CONTIGS}/contigs.fa
+    samtools faidx ${OUTFOLDER}/${CONTIGS}/contigs.fa
 
-    parallel --jobs "${PROCESSORS}" 'samtools mpileup -f' "${MAINFOLDER}"/"${CONTIGS}"/contigs.fa '"$( echo {} | sed 's/"${FILEID}"//' | sed s/\.[^.]*$// )".bam' -A '> "$( echo {} | sed 's/"${FILEID}"//' | sed s/\.[^.]*$// )".pileups' ::: "${FILELIST[@]}" "${FILELISTU[@]}"
-    parallel --jobs "${PROCESSORS}" "${DIR}/libexec/sisrs/specific_genome.py {} ${MAINFOLDER}/${CONTIGS}/contigs.fa" ::: "${FOLDERLISTA[@]}"
+    parallel --jobs "${PROCESSORS}" 'samtools mpileup -f' "${OUTFOLDER}"/"${CONTIGS}"/contigs.fa '"$( echo {} | sed 's/"${FILEID}"//' | sed s/\.[^.]*$// )".bam' -A '> "$( echo {} | sed 's/"${FILEID}"//' | sed s/\.[^.]*$// )".pileups' ::: "${FILELIST[@]}" "${FILELISTU[@]}"
+    parallel --jobs "${PROCESSORS}" "${DIR}/libexec/sisrs/specific_genome.py {} ${OUTFOLDER}/${CONTIGS}/contigs.fa" ::: "${FOLDERLISTA[@]}"
 
     if [[ $? != 0 ]]; then
         echo "specific_genome.py failed"
@@ -327,9 +367,9 @@ identifyFixedSites(){
 
 outputAlignment(){
     if [ -n "${REFFILE}" ]; then
-        ${DIR}/libexec/sisrs/get_alignment.py $((${#FOLDERLISTA[@]} - 2)) ${REFFILE} ${MAINFOLDER} ${ASSEMBLER}
+        ${DIR}/libexec/sisrs/get_alignment.py $((${#FOLDERLISTA[@]} - 2)) ${REFFILE} ${OUTFOLDER} ${ASSEMBLER}
     else
-        ${DIR}/libexec/sisrs/get_alignment.py $((${#FOLDERLISTA[@]} - 2)) X ${MAINFOLDER} ${ASSEMBLER}       #alignment with up to all but 2 missing
+        ${DIR}/libexec/sisrs/get_alignment.py $((${#FOLDERLISTA[@]} - 2)) X ${OUTFOLDER} ${ASSEMBLER}       #alignment with up to all but 2 missing
     fi
     if [[ $? != 0 ]]; then
         echo "get_alignment.py failed"
@@ -340,7 +380,7 @@ outputAlignment(){
 
 changeMissing(){
     if [[ ${MISSING} -lt $((${#FOLDERLISTA[@]} - 2)) ]]; then
-        ${DIR}/libexec/sisrs/filter_nexus_for_missing.py ${MAINFOLDER}/alignment.nex ${MISSING}       #alignment w specified number missing
+        ${DIR}/libexec/sisrs/filter_nexus_for_missing.py ${OUTFOLDER}/alignment.nex ${MISSING}       #alignment w specified number missing
     fi
     if [[ $? != 0 ]]; then
         echo "filtering for missing failed"
@@ -362,44 +402,44 @@ runSISRS(){
         ${cmds[$i]}
     done
 
-    #run as raxml -s "${MAINFOLDER}"/alignment_mX.phylip-relaxed -n <out> -m ASC_GTRGAMMA [--asc-corr=lewis] -T $1 -f a -p $RANDOM -N 100 -x $RANDOM
+    #run as raxml -s "${OUTFOLDER}"/alignment_mX.phylip-relaxed -n <out> -m ASC_GTRGAMMA [--asc-corr=lewis] -T $1 -f a -p $RANDOM -N 100 -x $RANDOM
 }
 
 ####################LOCI#######################
 
 copyRefContigs(){
-    grep -oe "[A-Z]*_*[0-9]*_*len[^/]*" "${MAINFOLDER}/alignment.nex" | uniq -c | sort -k1 -nr | awk '{print $2}' > "${MAINFOLDER}/loci.txt"
-    parallel --jobs "${PROCESSORS}" "${DIR}/libexec/gfr/get_seq.py" '{}/contigs.fa' "${MAINFOLDER}/loci.txt" '{}/ref_genes.fa'  ::: "${FOLDERLISTA[@]}"
+    grep -oe "[A-Z]*_*[0-9]*_*len[^/]*" "${OUTFOLDER}/alignment.nex" | uniq -c | sort -k1 -nr | awk '{print $2}' > "${OUTFOLDER}/loci.txt"
+    parallel --jobs "${PROCESSORS}" "${DIR}/libexec/gfr/get_seq.py" '{}/contigs.fa' "${OUTFOLDER}/loci.txt" '{}/ref_genes.fa'  ::: "${FOLDERLISTA[@]}"
 }
 
 fromRefToSpRef(){
-    grep \> "${MAINFOLDER}"/ref_genes.fa | sed 's/>//' |sort|uniq > "${MAINFOLDER}"/loci.txt
-    bowtie2-build ${MAINFOLDER}/ref_genes.fa ${MAINFOLDER}/ref_genes      #index
+    grep \> "${OUTFOLDER}"/ref_genes.fa | sed 's/>//' |sort|uniq > "${OUTFOLDER}"/loci.txt
+    bowtie2-build ${OUTFOLDER}/ref_genes.fa ${OUTFOLDER}/ref_genes      #index
 
     #align reads to contigs
     for FILE in "${FILELIST[@]}"; do
         NAME=$( echo ${FILE} | sed s/${FILEID}// | sed 's/\.[^.]*$//' ) #includes folder but not the read or the extension
         echo ==== Aligning FILELIST ${NAME}  ====
         #N=1 allows a mismatch #x The basename of the index for the reference genome
-        bowtie2 -p "${PROCESSORS}" -N 1 --local -x ${MAINFOLDER}/ref_genes -1 ${FILE} -2 $( echo ${FILE}|sed s/${FILEID}/${FILEID2}/ ) > >(tee ${NAME}_stdout.log) 2> >(tee ${NAME}_stderr.log >&2) | samtools -@ "${PROCESSORS}" view -Su -F 4 - | samtools sort -@ "${PROCESSORS}"- -o ${NAME}.bam
+        bowtie2 -p "${PROCESSORS}" -N 1 --local -x ${OUTFOLDER}/ref_genes -1 ${FILE} -2 $( echo ${FILE}|sed s/${FILEID}/${FILEID2}/ ) > >(tee ${NAME}_stdout.log) 2> >(tee ${NAME}_stderr.log >&2) | samtools -@ "${PROCESSORS}" view -Su -F 4 - | samtools sort -@ "${PROCESSORS}"- -o ${NAME}.bam
     done
     for FILE in "${FILELISTU[@]}"; do
         NAME=$( echo ${FILE} | sed 's/\.[^.]*$//' ) #includes folder but not the read or the extension
         echo ==== Aligning FILELISTU ${NAME} ====
         #N=1 allows a mismatch #x The basename of the index for the reference genome
-        bowtie2 -p "${PROCESSORS}" -N 1 --local -x ${MAINFOLDER}/ref_genes -U ${FILE} > >(tee ${NAME}_stdout.log) 2> >(tee ${NAME}_stderr.log >&2) | samtools view -Su -@ "${PROCESSORS}" -F 4 - | samtools sort -@ "${PROCESSORS}" - -o ${NAME}.bam
+        bowtie2 -p "${PROCESSORS}" -N 1 --local -x ${OUTFOLDER}/ref_genes -U ${FILE} > >(tee ${NAME}_stdout.log) 2> >(tee ${NAME}_stderr.log >&2) | samtools view -Su -@ "${PROCESSORS}" -F 4 - | samtools sort -@ "${PROCESSORS}" - -o ${NAME}.bam
     done
 
-    samtools faidx ${MAINFOLDER}/ref_genes.fa
-    parallel --jobs "${PROCESSORS}" "samtools mpileup -f ${MAINFOLDER}/ref_genes.fa" '$( echo {} | sed s/${FILEID}// | sed 's/\.[^.]*$//' ).bam -A > $( echo {} | sed s/${FILEID}// | sed 's/\.[^.]*$//' ).pileups' ::: "${FILELIST[@]}" "${FILELISTU[@]}"
-    parallel --jobs "${PROCESSORS}" "${DIR}/libexec/sisrs/specific_genome.py" {} ${MAINFOLDER}/ref_genes.fa ::: "${FOLDERLISTA[@]}"
+    samtools faidx ${OUTFOLDER}/ref_genes.fa
+    parallel --jobs "${PROCESSORS}" "samtools mpileup -f ${OUTFOLDER}/ref_genes.fa" '$( echo {} | sed s/${FILEID}// | sed 's/\.[^.]*$//' ).bam -A > $( echo {} | sed s/${FILEID}// | sed 's/\.[^.]*$//' ).pileups' ::: "${FILELIST[@]}" "${FILELISTU[@]}"
+    parallel --jobs "${PROCESSORS}" "${DIR}/libexec/sisrs/specific_genome.py" {} ${OUTFOLDER}/ref_genes.fa ::: "${FOLDERLISTA[@]}"
 
     parallel --jobs "${PROCESSORS}" mv {}/contigs.fa {}/ref_genes.fa  ::: "${FOLDERLISTA[@]}"
 }
 
 gfr_aligntoConservedContigs(){
     parallel --jobs "${PROCESSORS}" bowtie2-build '{}/ref_genes.fa {}/ref_genes' ::: "${FOLDERLISTA[@]}"   #build index for conserved contigs
-    find "${MAINFOLDER}"/*_loci/ -type f -name '*bam' | parallel -j "${PROCESSORS}" rm -f {}    #delete old bam
+    find "${OUTFOLDER}"/*_loci/ -type f -name '*bam' | parallel -j "${PROCESSORS}" rm -f {}    #delete old bam
 
     for FOLDER in "${FOLDERLIST[@]}"; do
         for FILE in "${FOLDER}"/*${FILEID}*fastq; do
@@ -438,67 +478,67 @@ gfr_getAlleles(){
 }
 
 gfr_getAlignments(){
-    ${DIR}/libexec/gfr/genealign_from_allgenes.py ${ALLELES} "${MAINFOLDER}"  #make files for each gene containing seq for each species
+    ${DIR}/libexec/gfr/genealign_from_allgenes.py ${ALLELES} "${OUTFOLDER}"  #make files for each gene containing seq for each species
 
-    for F in "${FOLDERLISTA[@]}"; do mv "${MAINFOLDER}"/loci/$(basename ${F}).fa "${MAINFOLDER}"/loci/$(basename ${F}).fasta; done   # move species fasta files so not aligned
+    for F in "${FOLDERLISTA[@]}"; do mv "${OUTFOLDER}"/loci/$(basename ${F}).fa "${OUTFOLDER}"/loci/$(basename ${F}).fasta; done   # move species fasta files so not aligned
 
-    find "${MAINFOLDER}"/loci/ -type f -name '*fa' | parallel -j "${PROCESSORS}" "mafft {} > {.}_align.fa"      #align
+    find "${OUTFOLDER}"/loci/ -type f -name '*fa' | parallel -j "${PROCESSORS}" "mafft {} > {.}_align.fa"      #align
 
 }
 
 gfr_trimLoci(){
 
-    find "${MAINFOLDER}"/loci/ -type f -name '*align.fa' | parallel -j "${PROCESSORS}" "${DIR}/libexec/gfr/convert_formats.py {} fasta phylip-relaxed"     #convert to phy
+    find "${OUTFOLDER}"/loci/ -type f -name '*align.fa' | parallel -j "${PROCESSORS}" "${DIR}/libexec/gfr/convert_formats.py {} fasta phylip-relaxed"     #convert to phy
 
-    find "${MAINFOLDER}"/loci/ -type f -name '*_align.phylip-relaxed' | parallel -j "${PROCESSORS}" "${DIR}/libexec/gfr/trim_post_alignment.py {} ${#FOLDERLISTA[@]}"    #trim ends
+    find "${OUTFOLDER}"/loci/ -type f -name '*_align.phylip-relaxed' | parallel -j "${PROCESSORS}" "${DIR}/libexec/gfr/trim_post_alignment.py {} ${#FOLDERLISTA[@]}"    #trim ends
 }
 
 gfr_selectLoci_MV(){
     #pick out loci by most variable in alignment.nex
     COUNT=0
     POS=1
-    if [[ -e "${MAINFOLDER}"/loci/newpartitionsMV.txt ]]; then rm "${MAINFOLDER}"/loci/newpartitionsMV.txt; fi
-    if [[ -e "${MAINFOLDER}"/loci/phy_filesMV.txt ]]; then rm "${MAINFOLDER}"/loci/phy_filesMV.txt; fi
+    if [[ -e "${OUTFOLDER}"/loci/newpartitionsMV.txt ]]; then rm "${OUTFOLDER}"/loci/newpartitionsMV.txt; fi
+    if [[ -e "${OUTFOLDER}"/loci/phy_filesMV.txt ]]; then rm "${OUTFOLDER}"/loci/phy_filesMV.txt; fi
 
     while read i; do
 
         F=${i}_align.phylip-relaxed
-        if [[ -e "${MAINFOLDER}"/loci/$F ]]; then
+        if [[ -e "${OUTFOLDER}"/loci/$F ]]; then
             COUNT=$(( $COUNT + 1 ))
-            GLENGTH=$(head -1 "${MAINFOLDER}"/loci/$F|awk '{print $2}')
-            echo DNA, p${COUNT}=${POS}-$((${POS}-1+${GLENGTH})) >> "${MAINFOLDER}"/loci/newpartitionsMV.txt           #get partitions
+            GLENGTH=$(head -1 "${OUTFOLDER}"/loci/$F|awk '{print $2}')
+            echo DNA, p${COUNT}=${POS}-$((${POS}-1+${GLENGTH})) >> "${OUTFOLDER}"/loci/newpartitionsMV.txt           #get partitions
             POS=$((${POS}+${GLENGTH}))
-            echo "${MAINFOLDER}"/loci/$F >> "${MAINFOLDER}"/loci/phy_filesMV.txt
+            echo "${OUTFOLDER}"/loci/$F >> "${OUTFOLDER}"/loci/phy_filesMV.txt
             if [[ $POS -gt ${OUTLENGTH} ]]; then
                 break
             fi
         fi
-    done < "${MAINFOLDER}"/loci.txt
+    done < "${OUTFOLDER}"/loci.txt
 }
 
 gfr_selectLoci_MS(){
     #pick out loci by most species, then most variable in alignment.nex
     COUNT=0
     POS=1
-    if [[ -e "${MAINFOLDER}"/loci/newpartitionsMS.txt ]]; then rm "${MAINFOLDER}"/loci/newpartitionsMS.txt; fi
-    if [[ -e "${MAINFOLDER}"/loci/phy_filesMS.txt ]]; then rm "${MAINFOLDER}"/loci/phy_filesMS.txt; fi
+    if [[ -e "${OUTFOLDER}"/loci/newpartitionsMS.txt ]]; then rm "${OUTFOLDER}"/loci/newpartitionsMS.txt; fi
+    if [[ -e "${OUTFOLDER}"/loci/phy_filesMS.txt ]]; then rm "${OUTFOLDER}"/loci/phy_filesMS.txt; fi
 
     for ((NUMSP="${#FOLDERLISTA[@]}";NUMSP>1;NUMSP--)); do
         while read i; do
             F=${i}_align.phylip-relaxed
-            if [[ -e "${MAINFOLDER}"/loci/$F ]]; then
-                if [[ $(head -1 "${MAINFOLDER}"/loci/$F|awk '{print $1}') -eq ${NUMSP} ]]; then
+            if [[ -e "${OUTFOLDER}"/loci/$F ]]; then
+                if [[ $(head -1 "${OUTFOLDER}"/loci/$F|awk '{print $1}') -eq ${NUMSP} ]]; then
                     COUNT=$(( $COUNT + 1 ))
-                    GLENGTH=$(head -1 "${MAINFOLDER}"/loci/$F|awk '{print $2}')
-                    echo DNA, p${COUNT}=${POS}-$((${POS}-1+${GLENGTH})) >> "${MAINFOLDER}"/loci/newpartitionsMS.txt           #get partitions
+                    GLENGTH=$(head -1 "${OUTFOLDER}"/loci/$F|awk '{print $2}')
+                    echo DNA, p${COUNT}=${POS}-$((${POS}-1+${GLENGTH})) >> "${OUTFOLDER}"/loci/newpartitionsMS.txt           #get partitions
                     POS=$((${POS}+${GLENGTH}))
-                    echo "${MAINFOLDER}"/loci/$F >> "${MAINFOLDER}"/loci/phy_filesMS.txt
+                    echo "${OUTFOLDER}"/loci/$F >> "${OUTFOLDER}"/loci/phy_filesMS.txt
                     if [[ $POS -gt 500000 ]] ; then
                         break
                     fi
                 fi
             fi
-        done < "${MAINFOLDER}"/loci.txt
+        done < "${OUTFOLDER}"/loci.txt
         if [[ $POS -gt ${OUTLENGTH} ]] ; then
             break
         fi
@@ -506,12 +546,12 @@ gfr_selectLoci_MS(){
 }
 
 gfr_catLoci(){
-    ${DIR}/libexec/gfr/concatenate_phy.py "${MAINFOLDER}"/loci/phy_filesMS.txt "${MAINFOLDER}"/loci/concat_lociMS.phylip-relaxed "${FOLDERLISTA[@]}"        #concatenate selected loci for raxml analysis
-    ${DIR}/libexec/gfr/concatenate_phy.py "${MAINFOLDER}"/loci/phy_filesMV.txt "${MAINFOLDER}"/loci/concat_lociMV.phylip-relaxed "${FOLDERLISTA[@]}"
-    #run as raxml -r <known_tree> -M -m GTRGAMMA -p $RANDOM -T <num_threads> -q "${MAINFOLDER}"/loci/newpartitions.txt -s "${MAINFOLDER}"/loci/concat_loci.phylip-relaxed -n <out_name>
+    ${DIR}/libexec/gfr/concatenate_phy.py "${OUTFOLDER}"/loci/phy_filesMS.txt "${OUTFOLDER}"/loci/concat_lociMS.phylip-relaxed "${FOLDERLISTA[@]}"        #concatenate selected loci for raxml analysis
+    ${DIR}/libexec/gfr/concatenate_phy.py "${OUTFOLDER}"/loci/phy_filesMV.txt "${OUTFOLDER}"/loci/concat_lociMV.phylip-relaxed "${FOLDERLISTA[@]}"
+    #run as raxml -r <known_tree> -M -m GTRGAMMA -p $RANDOM -T <num_threads> -q "${OUTFOLDER}"/loci/newpartitions.txt -s "${OUTFOLDER}"/loci/concat_loci.phylip-relaxed -n <out_name>
 
-    ${DIR}/libexec/gfr/convert_formats.py "${MAINFOLDER}"/loci/concat_lociMS.phylip-relaxed phylip-relaxed mega       #convert format to mega for reltime
-    ${DIR}/libexec/gfr/convert_formats.py "${MAINFOLDER}"/loci/concat_lociMV.phylip-relaxed phylip-relaxed mega       #convert format to mega for reltime
+    ${DIR}/libexec/gfr/convert_formats.py "${OUTFOLDER}"/loci/concat_lociMS.phylip-relaxed phylip-relaxed mega       #convert format to mega for reltime
+    ${DIR}/libexec/gfr/convert_formats.py "${OUTFOLDER}"/loci/concat_lociMV.phylip-relaxed phylip-relaxed mega       #convert format to mega for reltime
 }
 
 runGFR(){
@@ -524,10 +564,10 @@ runGFR(){
     gfr_aligntoConservedContigs
     gfr_mergebam
 
-    if [ ! -d "${MAINFOLDER}"/loci ]; then
-        mkdir "${MAINFOLDER}"/loci
+    if [ ! -d "${OUTFOLDER}"/loci ]; then
+        mkdir "${OUTFOLDER}"/loci
     else
-        find "${MAINFOLDER}"/loci/ -type f -name '*' | parallel -j "${PROCESSORS}" "rm -f {}"    #delete old loci
+        find "${OUTFOLDER}"/loci/ -type f -name '*' | parallel -j "${PROCESSORS}" "rm -f {}"    #delete old loci
     fi
 
     gfr_getAlleles
@@ -547,10 +587,10 @@ elif [[ $CMD = "loci" ]]; then
     # Run SISRS with loci (GFR). First check if alignment.nex and/or ref_genes.fa. If there is no alignment.nex then rerun SISRS to produce file.
     if [[ -f "${FOLDERLISTA[0]}"/ref_genes.fa ]]; then
         echo "** Running SISRS loci **"
-    elif [[ -f "${MAINFOLDER}"/alignment.nex ]]; then
+    elif [[ -f "${OUTFOLDER}"/alignment.nex ]]; then
         echo "** Missing reference, getting from SISRS sites alignment **"
 	copyRefContigs  # Get ref_genes.fa from previous sisrs run
-    elif [[ -f "${MAINFOLDER}"/ref_genes.fa ]]; then
+    elif [[ -f "${OUTFOLDER}"/ref_genes.fa ]]; then
         echo "** Getting species specific references **"
         fromRefToSpRef
     else
@@ -569,6 +609,7 @@ if [[ DEBUG -eq 1 ]]; then
     echo "DIRS          = ${DIRS}"
     echo "DIR           = ${DIR}"
     echo "MAINFOLDER    = ${MAINFOLDER}"
+    echo "OUTFOLDER     = ${OUTFOLDER}"
     echo "FILELIST      = ${FILELIST[@]}"
     echo "FOLDERLIST    = ${FOLDERLIST[@]}"
     echo "FILELISTA     = ${FILELISTA}"

--- a/bin/sisrs
+++ b/bin/sisrs
@@ -173,14 +173,15 @@ function join_by { local IFS="$1"; shift; echo "$*"; }
 
 if [[ "${MAINFOLDER}" = "${OUTFOLDER}" ]] || [[ -z $OUTFOLDER ]]; then     #Check if data folder and output folder are the same
     echo "Note: SISRS writing into data folder"
-    OUTFOLDER="${MAINFOLDER}"
+    OUTFOLDER=$( echo "${MAINFOLDER}" | sed -e "s/\/*$//" )
 
 elif [[ "${CMD}" = "alignContigs" ]] || [[ "${CMD}" = "mapContigs" ]] || [[ "${CMD}" = "identifyFixedSites" ]] || [[ "${CMD}" = "outputAlignment" ]] || [[ "${CMD}" = "changeMissing" ]]; then
     echo "For ${CMD}, data folder (-f) and output folder (-z) must be the same. Aborting."
     exit 1
 
 elif [[ ! -d "${OUTFOLDER}" ]]; then
-    cp -as "${MAINFOLDER}" "${OUTFOLDER}"     #Create output directory with links to data files if directory does not already exist
+    cp -as "${MAINFOLDER}" "${OUTFOLDER}" #Create output directory with links to data files if directory does not already exist
+    OUTFOLDER=$( echo "${OUTFOLDER}" | sed -e "s/\/*$//" )
 
 else
     echo "${OUTFOLDER} already exists. Checking if empty..."
@@ -190,6 +191,7 @@ else
     else
         echo "${OUTFOLDER} exists and is empty. SISRS continuing..."
         cp -as "${MAINFOLDER}/"* "${OUTFOLDER}"   #Populate exisiting empty output directory with links to data files
+        OUTFOLDER=$( echo "${OUTFOLDER}" | sed -e "s/\/*$//" )
     fi
 fi
 

--- a/bin/sisrs
+++ b/bin/sisrs
@@ -341,7 +341,7 @@ mapContigs(){
 identifyFixedSites(){
     samtools faidx ${OUTFOLDER}/${CONTIGS}/contigs.fa
 
-    parallel --jobs "${PROCESSORS}" 'samtools mpileup -f '${OUTFOLDER}'/'${CONTIGS}'/contigs.fa "$( echo {}/$(basename {} ) )".bam ">" "$( echo {}/$(basename {} ) )".pileups' ::: "${FOLDERLISTA[@]}"
+    parallel --jobs "${PROCESSORS}" 'samtools mpileup -f "${OUTFOLDER}"/"${CONTIGS}"/contigs.fa "$( echo {}/$(basename {} ) )".bam ">" "$( echo {}/$(basename {} ) )".pileups' ::: "${FOLDERLISTA[@]}"
     parallel --jobs "${PROCESSORS}" "${DIR}/libexec/sisrs/specific_genome.py {} ${OUTFOLDER}/${CONTIGS}/contigs.fa" ::: "${FOLDERLISTA[@]}"
 
     if [[ $? != 0 ]]; then

--- a/bin/sisrs
+++ b/bin/sisrs
@@ -448,9 +448,6 @@ fromRefToSpRef(){
     #align reads to contigs
     for FOLDER in "${FOLDERLISTA[@]}";do
         FOLDERNAME=( $(echo $(basename ${FOLDER} ) ) )
-        mv ${FOLDER}/${FOLDERNAME}.bam > ${FOLDER}/${FOLDERNAME}.bam_sites
-        mv ${FOLDER}/${FOLDERNAME}.bam.bai > ${FOLDER}/${FOLDERNAME}.bam.bai_sites
-        mv ${FOLDER}/${FOLDERNAME}.pileups > ${FOLDER}/${FOLDERNAME}.pileups_sites
         FASTQ=( $( find ${FOLDER} -name "*fastq" ) )
         FASTQLIST=( $(join_by , "${FASTQ[@]}"))
         echo ==== Aligning ${FOLDERNAME} as Single-Ended ====

--- a/bin/sisrs
+++ b/bin/sisrs
@@ -326,7 +326,7 @@ alignContigs(){
 
 mapContigs(){
     #index bam
-    parallel --jobs "${PROCESSORS}" 'samtools index "$( echo {}"/"$(basename {} ) )".bam' ::: "${FOLDERLISTA[@]}"
+    parallel --jobs "${PROCESSORS}" 'samtools index "$( echo {}/$(basename {} ) )".bam' ::: "${FOLDERLISTA[@]}"
     echo ==== Done Indexing Bam Files ====
 
     #map contigs to reference
@@ -341,7 +341,7 @@ mapContigs(){
 identifyFixedSites(){
     samtools faidx ${OUTFOLDER}/${CONTIGS}/contigs.fa
 
-    parallel --jobs "${PROCESSORS}" 'samtools mpileup -f' "${OUTFOLDER}"/"${CONTIGS}"/contigs.fa '"$( echo {} | sed 's/"${FILEID}"//' | sed s/\.[^.]*$// )".bam' -A '> "$( echo {} | sed 's/"${FILEID}"//' | sed s/\.[^.]*$// )".pileups' ::: "${FILELIST[@]}" "${FILELISTU[@]}"
+    parallel --jobs "${PROCESSORS}" 'samtools mpileup -f' "${OUTFOLDER}"/"${CONTIGS}"/contigs.fa "$( echo {}/$(basename {} ) )".bam > "$( echo {}/$(basename {} ) )".pileups ::: "${FOLDERLISTA[@]}" "${FOLDERLISTA[@]}"
     parallel --jobs "${PROCESSORS}" "${DIR}/libexec/sisrs/specific_genome.py {} ${OUTFOLDER}/${CONTIGS}/contigs.fa" ::: "${FOLDERLISTA[@]}"
 
     if [[ $? != 0 ]]; then
@@ -353,6 +353,21 @@ identifyFixedSites(){
     parallel --jobs "${PROCESSORS}" 'bowtie2-build' {}/contigs.fa {}/contigs ::: "${FOLDERLISTA[@]}"
 
     #align reads to contigs
+    for FOLDER in "${FOLDERLISTA[@]}";do
+        FASTQ=( $( find ${FOLDER} -name "*fastq" ) )
+        FASTQLIST=( $(join_by , "${FASTQ[@]}"))
+        FOLDERNAME=( $(echo $(basename ${FOLDER} ) ) )
+        echo ==== Aligning ${FOLDERNAME} as Single-Ended ====
+        #Align all species reads against composite genome. N=1 allows a mismatch #x The basename of the index for the reference genome
+        bowtie2 -p "${PROCESSORS}" -N 1 --local -x ${FOLDER}/contigs -U ${FASTQLIST} | samtools view -Su -@ "${PROCESSORS}" -F 4 - | samtools sort -@ "${PROCESSORS}" - -o ${FOLDER}/${FOLDERNAME}_Temp.bam
+        #Extract uniquely mapping reads
+        samtools view -@ "${PROCESSORS}" -H ${FOLDER}/${FOLDERNAME}_Temp.bam > ${FOLDER}/${FOLDERNAME}_Header.sam
+        samtools view -@ "${PROCESSORS}" ${FOLDER}/${FOLDERNAME}_Temp.bam | grep -v "XS:" | cat ${FOLDER}/${FOLDERNAME}_Header.sam - | samtools view -@ "${PROCESSORS}" -b - > ${FOLDER}/${FOLDERNAME}.bam
+        #Remove temporary files
+        rm ${FOLDER}/${FOLDERNAME}_Temp.bam
+        rm ${FOLDER}/${FOLDERNAME}_Header.sam
+    done
+    echo =============DONERAL==================
     for FILE in "${FILELIST[@]}"; do
         NAME=$( echo ${FILE} | sed s/${FILEID}// | sed 's/\.[^.]*$//' )
         echo ==== Aligning FILELIST ${NAME}  ====

--- a/bin/sisrs
+++ b/bin/sisrs
@@ -459,7 +459,7 @@ copyRefContigs(){
   if [[ -e "${OUTFOLDER}/locs_m${MISSING}_Clean.txt" ]];then
     parallel --jobs "${PROCESSORS}" "${DIR}/libexec/gfr/get_seq.py" '{}/contigs.fa' "${OUTFOLDER}/locs_m${MISSING}_Clean.txt" '{}/ref_genes.fa'  ::: "${FOLDERLISTA[@]}"
   else
-    echo locs_m${MISSING}_Clean.txt not found in ${OUTFOLDER}, must first run ""sisrs changeMissing -f ${OUTFOLDER} -m ${MISSING}-c 0"". Aborting...; exit 1;
+    echo locs_m${MISSING}_Clean.txt not found in ${OUTFOLDER}, must first run \sisrs changeMissing -f ${OUTFOLDER} -m ${MISSING} -c 0\". Aborting...; exit 1;
   fi
 }
 

--- a/bin/sisrs
+++ b/bin/sisrs
@@ -341,7 +341,7 @@ mapContigs(){
 identifyFixedSites(){
     samtools faidx ${OUTFOLDER}/${CONTIGS}/contigs.fa
 
-    parallel --jobs "${PROCESSORS}" 'samtools mpileup -f' "${OUTFOLDER}"/"${CONTIGS}"/contigs.fa '"$( echo {}/$(basename {} ) )".bam' > '"$( echo {}/$(basename {} ) )".pileups' ::: "${FOLDERLISTA[@]}" "${FOLDERLISTA[@]}" "${FOLDERLISTA[@]}" "${FOLDERLISTA[@]}"
+    parallel --jobs "${PROCESSORS}" 'samtools mpileup -f' "${OUTFOLDER}"/"${CONTIGS}"/contigs.fa "$( echo {}/$(basename {} ) )".bam > "$( echo {}/$(basename {} ) )".pileups ::: "${FOLDERLISTA[@]}" "${FOLDERLISTA[@]}" "${FOLDERLISTA[@]}" "${FOLDERLISTA[@]}"
     parallel --jobs "${PROCESSORS}" "${DIR}/libexec/sisrs/specific_genome.py {} ${OUTFOLDER}/${CONTIGS}/contigs.fa" ::: "${FOLDERLISTA[@]}"
 
     if [[ $? != 0 ]]; then

--- a/bin/sisrs
+++ b/bin/sisrs
@@ -341,7 +341,7 @@ mapContigs(){
 identifyFixedSites(){
     samtools faidx ${OUTFOLDER}/${CONTIGS}/contigs.fa
 
-    parallel --jobs "${PROCESSORS}" 'samtools mpileup -f' "${OUTFOLDER}"/"${CONTIGS}"/contigs.fa "$( echo {}/$(basename {} ) )".bam > "$( echo {}/$(basename {} ) )".pileups ::: "${FOLDERLISTA[@]}" "${FOLDERLISTA[@]}" "${FOLDERLISTA[@]}" "${FOLDERLISTA[@]}"
+    parallel --jobs "${PROCESSORS}" 'samtools mpileup -f' "${OUTFOLDER}"/"${CONTIGS}"/contigs.fa 'echo "$( echo {}/$(basename {} ) )".bam' > 'echo "$( echo {}/$(basename {} ) )".pileups' ::: "${FOLDERLISTA[@]}"
     parallel --jobs "${PROCESSORS}" "${DIR}/libexec/sisrs/specific_genome.py {} ${OUTFOLDER}/${CONTIGS}/contigs.fa" ::: "${FOLDERLISTA[@]}"
 
     if [[ $? != 0 ]]; then

--- a/bin/sisrs
+++ b/bin/sisrs
@@ -9,7 +9,7 @@ VERSION=1.6
 
 help() {
     cat <<ENDLINE
-    
+
  SISRS: Site Identification from Short Read Sequences
  Version 1.6
  Copyright (c) 2013-2015 Rachel Schwartz <Rachel.Schwartz@asu.edu>
@@ -41,9 +41,9 @@ Commands:
         fewer than a specified number of samples per site
  loci : produce a set of aligned loci based on the most variable regions of
         the composite genome
- 
+
 Flags:
-    
+
  -g : MANDATORY if running sisrs from the beginning - the approximate genome size
       - this will reduce the size of the composite assembly by using a subset
       of reads to approximate 10x coverage
@@ -63,7 +63,7 @@ Flags:
 
  Example command:
  sisrs sites -g 1745690 -p 40 -m 4 -f test_data
- 
+
  Example command:
  sisrs loci -g 1745690 -p 40 -m 4 -f test_data
 
@@ -86,8 +86,8 @@ cmds=(subSample buildContigs alignContigs mapContigs identifyFixedSites outputAl
 if [[ "${CMD}" != "sites" ]] && [[ "${CMD}" != "loci" ]] && [[ ! "${cmds[*]}" =~ $CMD ]]; then
     help
     exit 0
-fi 
-    
+fi
+
 OPTIND=2 # tells getopts to start parsing at the second argument
 
 while getopts g:r:k:p:m:a:f:n:t:o:l:hd option
@@ -151,7 +151,7 @@ which samtools &>/dev/null
 
 ###########actions##############
 
-FILELISTA=( $( find "${MAINFOLDER}" -name "*fastq" ) )   
+FILELISTA=( $( find "${MAINFOLDER}" -name "*fastq" ) )
 
 #get paired fastq
 FILELIST=( $( find "${MAINFOLDER}" -name *${FILEID}*fastq ) )     #all fastq file paths as array
@@ -188,7 +188,7 @@ subSample(){
         echo "You must enter the approximate size of the genome / transcriptome. For more information run sisrs -h"
         exit 1
     fi
-    
+
     echo "Subsampling data"
     if [[ -e "${MAINFOLDER}"/subsamples ]]; then rm -r "${MAINFOLDER}"/subsamples; fi
     NUMER=$((10*${GENOMESIZE}))
@@ -196,7 +196,7 @@ subSample(){
     LEFTREADS=$((${NUMER}/${DENOM}))
     mkdir ${MAINFOLDER}/subsamples
     parallel --jobs "${PROCESSORS}" "${DIR}/libexec/sisrs/sub_sample_for_velvet_unshuff.py ${LEFTREADS} {} ${FILEID} ${FILEID2}" ::: "${FOLDERLISTA[@]}"   #subsample data and shuffle
-    
+
     if [[ $? != 0 ]]; then
         echo "Subsampling failed"
         exit 1
@@ -235,18 +235,18 @@ buildContigs(){
             fi
         fi
         echo ==== Velveth is finished ====
-        
+
         velvetg ${MAINFOLDER}/velvetoutput -exp_cov auto -cov_cutoff auto# -min_contig_lgth 100     #run velvet - output contigs
         echo ==== Velvetg is finished ===
     fi
-    
+
     if [[ $ASSEMBLER == "minia" ]]; then
         mkdir ${MAINFOLDER}/miniaoutput
         ls ${MAINFOLDER}/subsamples/*fastq | parallel -j ${PROCESSORS} basename > ${MAINFOLDER}/subsamples/minia_read_file.txt
         minia -in ${MAINFOLDER}/subsamples/minia_read_file.txt -kmer-size ${KMER} -nb-cores "${PROCESSORS}" -out ${MAINFOLDER}/miniaoutput/
         mv ${MAINFOLDER}/miniaoutput/.contigs.fa ${MAINFOLDER}/miniaoutput/contigs.fa
     fi
-    
+
     if [[ $ASSEMBLER == "ABYSS" ]]; then
         mkdir ${MAINFOLDER}/abyssoutput
         ABYSS -k ${KMER} -o ${MAINFOLDER}/abyssoutput/contigs.fa ${MAINFOLDER}/subsamples/*fastq
@@ -255,7 +255,7 @@ buildContigs(){
 
 alignContigs(){
     bowtie2-build ${MAINFOLDER}/"${CONTIGS}"/contigs.fa ${MAINFOLDER}/"${CONTIGS}"/contigs      #index contigs
-    
+
     #align reads to contigs
     for FILE in "${FILELIST[@]}"; do
         NAME=$( echo ${FILE} | sed s/${FILEID}// | sed 's/\.[^.]*$//' ) #includes folder but not the read or the extension
@@ -271,12 +271,12 @@ alignContigs(){
     done
     echo ==== Done Aligning ====
 }
-    
+
 mapContigs(){
     #index bam
     parallel --jobs "${PROCESSORS}" 'samtools index "$( echo {} | sed 's/"${FILEID}"//' | sed s/\.[^.]*$// )".bam' ::: "${FILELIST[@]}"
     echo ==== Done Indexing Bam Files ====
-       
+
     #map contigs to reference
     if [ -n "${REFFILE}" ]; then
         NAME=$( echo ${REFFILE} | sed 's/\.[^.]*$//' )
@@ -288,10 +288,10 @@ mapContigs(){
 
 identifyFixedSites(){
     samtools faidx ${MAINFOLDER}/${CONTIGS}/contigs.fa
-    
+
     parallel --jobs "${PROCESSORS}" 'samtools mpileup -f' "${MAINFOLDER}"/"${CONTIGS}"/contigs.fa '"$( echo {} | sed 's/"${FILEID}"//' | sed s/\.[^.]*$// )".bam' -A '> "$( echo {} | sed 's/"${FILEID}"//' | sed s/\.[^.]*$// )".pileups' ::: "${FILELIST[@]}" "${FILELISTU[@]}"
     parallel --jobs "${PROCESSORS}" "${DIR}/libexec/sisrs/specific_genome.py {} ${MAINFOLDER}/${CONTIGS}/contigs.fa" ::: "${FOLDERLISTA[@]}"
-    
+
     if [[ $? != 0 ]]; then
         echo "specific_genome.py failed"
         exit 1
@@ -299,7 +299,7 @@ identifyFixedSites(){
 
     parallel --jobs "${PROCESSORS}" "samtools faidx {}/contigs.fa" ::: "${FOLDERLISTA[@]}"
     parallel --jobs "${PROCESSORS}" 'bowtie2-build' {}/contigs.fa {}/contigs ::: "${FOLDERLISTA[@]}"
-    
+
     #align reads to contigs
     for FILE in "${FILELIST[@]}"; do
         NAME=$( echo ${FILE} | sed s/${FILEID}// | sed 's/\.[^.]*$//' )
@@ -311,11 +311,11 @@ identifyFixedSites(){
         echo ==== Aligning FILELISTU ${NAME} ====
         bowtie2 -p "${PROCESSORS}" -N 1 --local -x $(dirname ${FILE})/contigs -U ${FILE} > >(tee ${NAME}_stdout.log) 2> >(tee ${NAME}_stderr.log >&2) | samtools view -Su -@ "${PROCESSORS}" -F 4 - | samtools sort -@ "${PROCESSORS}" - -o ${NAME}.bam
     done
-    
+
     parallel --jobs "${PROCESSORS}" 'samtools index "$( echo {} | sed 's/"${FILEID}"//' | sed s/\.[^.]*$// )".bam' ::: "${FILELIST[@]}"
-    
+
     parallel --jobs "${PROCESSORS}" 'samtools mpileup -f "$(dirname {})"/contigs.fa "$( echo {} | sed 's/"${FILEID}"//' | sed s/\.[^.]*$// )".bam -A > "$( echo {} | sed 's/"${FILEID}"//' | sed s/\.[^.]*$// )".pileups' ::: "${FILELIST[@]}" "${FILELISTU[@]}"
-    
+
     #put base for each site in a dictionary (allows no variation when calling sites)
     parallel --jobs "${PROCESSORS}" "${DIR}/libexec/sisrs/get_pruned_dict.py {} ${MINREAD} ${THRESHOLD}" ::: "${FOLDERLISTA[@]}"
     if [[ $? != 0 ]]; then
@@ -335,7 +335,7 @@ outputAlignment(){
         echo "get_alignment.py failed"
         exit 1
     fi
-    
+
 }
 
 changeMissing(){
@@ -361,7 +361,7 @@ runSISRS(){
     for (( i = $i; i < ${#cmds[@]}; i++ )); do      #run from selected opt to end
         ${cmds[$i]}
     done
-     
+
     #run as raxml -s "${MAINFOLDER}"/alignment_mX.phylip-relaxed -n <out> -m ASC_GTRGAMMA [--asc-corr=lewis] -T $1 -f a -p $RANDOM -N 100 -x $RANDOM
 }
 
@@ -374,8 +374,8 @@ copyRefContigs(){
 
 fromRefToSpRef(){
     grep \> "${MAINFOLDER}"/ref_genes.fa | sed 's/>//' |sort|uniq > "${MAINFOLDER}"/loci.txt
-    bowtie2-build ${MAINFOLDER}/ref_genes.fa ${MAINFOLDER}/ref_genes      #index 
-    
+    bowtie2-build ${MAINFOLDER}/ref_genes.fa ${MAINFOLDER}/ref_genes      #index
+
     #align reads to contigs
     for FILE in "${FILELIST[@]}"; do
         NAME=$( echo ${FILE} | sed s/${FILEID}// | sed 's/\.[^.]*$//' ) #includes folder but not the read or the extension
@@ -389,37 +389,37 @@ fromRefToSpRef(){
         #N=1 allows a mismatch #x The basename of the index for the reference genome
         bowtie2 -p "${PROCESSORS}" -N 1 --local -x ${MAINFOLDER}/ref_genes -U ${FILE} > >(tee ${NAME}_stdout.log) 2> >(tee ${NAME}_stderr.log >&2) | samtools view -Su -@ "${PROCESSORS}" -F 4 - | samtools sort -@ "${PROCESSORS}" - -o ${NAME}.bam
     done
-    
+
     samtools faidx ${MAINFOLDER}/ref_genes.fa
     parallel --jobs "${PROCESSORS}" "samtools mpileup -f ${MAINFOLDER}/ref_genes.fa" '$( echo {} | sed s/${FILEID}// | sed 's/\.[^.]*$//' ).bam -A > $( echo {} | sed s/${FILEID}// | sed 's/\.[^.]*$//' ).pileups' ::: "${FILELIST[@]}" "${FILELISTU[@]}"
-    parallel --jobs "${PROCESSORS}" "${DIR}/libexec/sisrs/specific_genome.py" {} ${MAINFOLDER}/ref_genes.fa ::: "${FOLDERLISTA[@]}"    
-    
+    parallel --jobs "${PROCESSORS}" "${DIR}/libexec/sisrs/specific_genome.py" {} ${MAINFOLDER}/ref_genes.fa ::: "${FOLDERLISTA[@]}"
+
     parallel --jobs "${PROCESSORS}" mv {}/contigs.fa {}/ref_genes.fa  ::: "${FOLDERLISTA[@]}"
 }
 
 gfr_aligntoConservedContigs(){
     parallel --jobs "${PROCESSORS}" bowtie2-build '{}/ref_genes.fa {}/ref_genes' ::: "${FOLDERLISTA[@]}"   #build index for conserved contigs
     find "${MAINFOLDER}"/*_loci/ -type f -name '*bam' | parallel -j "${PROCESSORS}" rm -f {}    #delete old bam
-    
+
     for FOLDER in "${FOLDERLIST[@]}"; do
         for FILE in "${FOLDER}"/*${FILEID}*fastq; do
 	    # output sorted bam file w/o unaligned reads - lots per folder
             echo Aligning ${FILE} to conserved contigs
-	    bowtie2 -p "${PROCESSORS}" -N 1 --local -x "${FOLDER}"/ref_genes -1 ${FILE} -2 $( echo ${FILE}|sed s/${FILEID}/${FILEID2}/ ) > >(tee ${FILE/.fastq/}_stdout.log) 2> >(tee ${FILE/.fastq/}_stderr.log >&2) | samtools view -Su -@ "${PROCESSORS}" -F 4 - | samtools sort -@ "${PROCESSORS}" - -o "$FOLDER"_loci/$(basename ${FILE/.fastq}).bam  
+	    bowtie2 -p "${PROCESSORS}" -N 1 --local -x "${FOLDER}"/ref_genes -1 ${FILE} -2 $( echo ${FILE}|sed s/${FILEID}/${FILEID2}/ ) > >(tee ${FILE/.fastq/}_stdout.log) 2> >(tee ${FILE/.fastq/}_stderr.log >&2) | samtools view -Su -@ "${PROCESSORS}" -F 4 - | samtools sort -@ "${PROCESSORS}" - -o "$FOLDER"_loci/$(basename ${FILE/.fastq}).bam
         done
     done
-    
+
     for FOLDER in "${FOLDERLISTU[@]}"; do
         for FILE in "${FOLDER}"/*reads*fastq; do
-            bowtie2 -p "${PROCESSORS}" -N 1 --local -x "${FOLDER}"/ref_genes -U ${FILE} > >(tee ${FILE/.fastq/}_stdout.log) 2> >(tee ${FILE/.fastq/}_stderr.log >&2) | samtools view -Su -@ "${PROCESSORS}" -F 4 - | samtools sort -@ "${PROCESSORS}" - -o "$FOLDER"_loci/$(basename ${FILE/.fastq}).bam  
-        done        
+            bowtie2 -p "${PROCESSORS}" -N 1 --local -x "${FOLDER}"/ref_genes -U ${FILE} > >(tee ${FILE/.fastq/}_stdout.log) 2> >(tee ${FILE/.fastq/}_stderr.log >&2) | samtools view -Su -@ "${PROCESSORS}" -F 4 - | samtools sort -@ "${PROCESSORS}" - -o "$FOLDER"_loci/$(basename ${FILE/.fastq}).bam
+        done
     done
 }
 
 gfr_mergebam(){
     declare -a TOMERGE=()
     for FOLDER in "${FOLDERLISTA[@]}"; do
-        rm -f "$FOLDER"_loci/merged.bam        # remove existing merged.bam file    
+        rm -f "$FOLDER"_loci/merged.bam        # remove existing merged.bam file
         if [[ $(ls -l "$FOLDER"_loci/*bam | wc -l) -eq 1 ]]; then      #if only one file just link
             F="$FOLDER"_loci/*bam
             ln $(echo "$F") "$FOLDER"_loci/merged.bam
@@ -439,17 +439,17 @@ gfr_getAlleles(){
 
 gfr_getAlignments(){
     ${DIR}/libexec/gfr/genealign_from_allgenes.py ${ALLELES} "${MAINFOLDER}"  #make files for each gene containing seq for each species
-    
+
     for F in "${FOLDERLISTA[@]}"; do mv "${MAINFOLDER}"/loci/$(basename ${F}).fa "${MAINFOLDER}"/loci/$(basename ${F}).fasta; done   # move species fasta files so not aligned
-        
+
     find "${MAINFOLDER}"/loci/ -type f -name '*fa' | parallel -j "${PROCESSORS}" "mafft {} > {.}_align.fa"      #align
-    
+
 }
 
 gfr_trimLoci(){
-   
+
     find "${MAINFOLDER}"/loci/ -type f -name '*align.fa' | parallel -j "${PROCESSORS}" "${DIR}/libexec/gfr/convert_formats.py {} fasta phylip-relaxed"     #convert to phy
-    
+
     find "${MAINFOLDER}"/loci/ -type f -name '*_align.phylip-relaxed' | parallel -j "${PROCESSORS}" "${DIR}/libexec/gfr/trim_post_alignment.py {} ${#FOLDERLISTA[@]}"    #trim ends
 }
 
@@ -459,7 +459,7 @@ gfr_selectLoci_MV(){
     POS=1
     if [[ -e "${MAINFOLDER}"/loci/newpartitionsMV.txt ]]; then rm "${MAINFOLDER}"/loci/newpartitionsMV.txt; fi
     if [[ -e "${MAINFOLDER}"/loci/phy_filesMV.txt ]]; then rm "${MAINFOLDER}"/loci/phy_filesMV.txt; fi
-    
+
     while read i; do
 
         F=${i}_align.phylip-relaxed
@@ -482,7 +482,7 @@ gfr_selectLoci_MS(){
     POS=1
     if [[ -e "${MAINFOLDER}"/loci/newpartitionsMS.txt ]]; then rm "${MAINFOLDER}"/loci/newpartitionsMS.txt; fi
     if [[ -e "${MAINFOLDER}"/loci/phy_filesMS.txt ]]; then rm "${MAINFOLDER}"/loci/phy_filesMS.txt; fi
-    
+
     for ((NUMSP="${#FOLDERLISTA[@]}";NUMSP>1;NUMSP--)); do
         while read i; do
             F=${i}_align.phylip-relaxed
@@ -504,12 +504,12 @@ gfr_selectLoci_MS(){
         fi
     done
 }
-  
-gfr_catLoci(){    
+
+gfr_catLoci(){
     ${DIR}/libexec/gfr/concatenate_phy.py "${MAINFOLDER}"/loci/phy_filesMS.txt "${MAINFOLDER}"/loci/concat_lociMS.phylip-relaxed "${FOLDERLISTA[@]}"        #concatenate selected loci for raxml analysis
     ${DIR}/libexec/gfr/concatenate_phy.py "${MAINFOLDER}"/loci/phy_filesMV.txt "${MAINFOLDER}"/loci/concat_lociMV.phylip-relaxed "${FOLDERLISTA[@]}"
     #run as raxml -r <known_tree> -M -m GTRGAMMA -p $RANDOM -T <num_threads> -q "${MAINFOLDER}"/loci/newpartitions.txt -s "${MAINFOLDER}"/loci/concat_loci.phylip-relaxed -n <out_name>
-    
+
     ${DIR}/libexec/gfr/convert_formats.py "${MAINFOLDER}"/loci/concat_lociMS.phylip-relaxed phylip-relaxed mega       #convert format to mega for reltime
     ${DIR}/libexec/gfr/convert_formats.py "${MAINFOLDER}"/loci/concat_lociMV.phylip-relaxed phylip-relaxed mega       #convert format to mega for reltime
 }
@@ -520,16 +520,16 @@ runGFR(){
             mkdir "$FOLDER"_loci
         fi
     done
-    
+
     gfr_aligntoConservedContigs
     gfr_mergebam
-    
+
     if [ ! -d "${MAINFOLDER}"/loci ]; then
         mkdir "${MAINFOLDER}"/loci
     else
         find "${MAINFOLDER}"/loci/ -type f -name '*' | parallel -j "${PROCESSORS}" "rm -f {}"    #delete old loci
     fi
-    
+
     gfr_getAlleles
     gfr_getAlignments
     gfr_trimLoci
@@ -544,7 +544,7 @@ if [[ $CMD = "sites" ]] || [[ "${cmds[*]}" =~ $CMD ]]; then
     echo "**** SISRS ****"
     runSISRS
 elif [[ $CMD = "loci" ]]; then
-    # Run SISRS with loci (GFR). First check if alignment.nex and/or ref_genes.fa. If there is no alignment.nex then rerun SISRS to produce file. 
+    # Run SISRS with loci (GFR). First check if alignment.nex and/or ref_genes.fa. If there is no alignment.nex then rerun SISRS to produce file.
     if [[ -f "${FOLDERLISTA[0]}"/ref_genes.fa ]]; then
         echo "** Running SISRS loci **"
     elif [[ -f "${MAINFOLDER}"/alignment.nex ]]; then
@@ -552,7 +552,7 @@ elif [[ $CMD = "loci" ]]; then
 	copyRefContigs  # Get ref_genes.fa from previous sisrs run
     elif [[ -f "${MAINFOLDER}"/ref_genes.fa ]]; then
         echo "** Getting species specific references **"
-        fromRefToSpRef        
+        fromRefToSpRef
     else
         # need to rerun SISRS from scratch to get ref_genes.fa
         echo "** Missing alignment and reference, running SISRS sites **"

--- a/bin/sisrs
+++ b/bin/sisrs
@@ -341,7 +341,7 @@ mapContigs(){
 identifyFixedSites(){
     samtools faidx ${OUTFOLDER}/${CONTIGS}/contigs.fa
 
-    parallel --jobs "${PROCESSORS}" 'samtools mpileup -f "${OUTFOLDER}"/"${CONTIGS}"/contigs.fa "$( echo {}/$(basename {} ) )".bam ">" "$( echo {}/$(basename {} ) )".pileups' ::: "${FOLDERLISTA[@]}"
+    parallel --jobs "${PROCESSORS}" 'samtools mpileup -f ${OUTFOLDER}/${CONTIGS}/contigs.fa "$( echo {}/$(basename {} ) )".bam ">" "$( echo {}/$(basename {} ) )".pileups' ::: "${FOLDERLISTA[@]}"
     parallel --jobs "${PROCESSORS}" "${DIR}/libexec/sisrs/specific_genome.py {} ${OUTFOLDER}/${CONTIGS}/contigs.fa" ::: "${FOLDERLISTA[@]}"
 
     if [[ $? != 0 ]]; then

--- a/bin/sisrs
+++ b/bin/sisrs
@@ -456,8 +456,13 @@ runSISRS(){
 ####################LOCI#######################
 
 copyRefContigs(){
+  if [[ -e "${OUTFOLDER}/locs_m${MISSING}_Clean.txt" ]];then
     parallel --jobs "${PROCESSORS}" "${DIR}/libexec/gfr/get_seq.py" '{}/contigs.fa' "${OUTFOLDER}/locs_m${MISSING}_Clean.txt" '{}/ref_genes.fa'  ::: "${FOLDERLISTA[@]}"
+  else
+    echo locs_m${MISSING}_Clean.txt not found in ${OUTFOLDER}, must first run 'sisrs changeMissing -f ${OUTFOLDER} -m {MISSING}-c 0'. Aborting...; exit 1;
+  fi
 }
+
 
 fromRefToSpRef(){
     grep \> "${OUTFOLDER}"/ref_genes.fa | sed 's/>//' |sort|uniq > "${OUTFOLDER}"/loci.txt

--- a/bin/sisrs
+++ b/bin/sisrs
@@ -229,7 +229,7 @@ if [[ $ASSEMBLER == "premade" ]];then
     }
 fi
 
-if [[ $ASSEMBLER!="premade" ]];then
+if [[ $ASSEMBLER !="premade" ]];then
     subSample(){
         if [ -z $GENOMESIZE ]; then
             echo "You must enter the approximate size of the genome / transcriptome. For more information run sisrs -h"

--- a/bin/sisrs
+++ b/bin/sisrs
@@ -326,14 +326,14 @@ alignContigs(){
 
 mapContigs(){
     #index bam
-    parallel --jobs "${PROCESSORS}" 'samtools index "$( echo {} | sed 's/"${FILEID}"//' | sed s/\.[^.]*$// )".bam' ::: "${FILELIST[@]}"
+    parallel --jobs "${PROCESSORS}" 'samtools index "$( echo {}"/"$(basename {} ) )".bam' ::: "${FOLDERLISTA[@]}"
     echo ==== Done Indexing Bam Files ====
 
     #map contigs to reference
     if [ -n "${REFFILE}" ]; then
         NAME=$( echo ${REFFILE} | sed 's/\.[^.]*$//' )
         bowtie2-build ${REFFILE} ${NAME}        #bowtie2-build [options]* <reference_in> <bt2_base>
-        bowtie2 -p ${PROCESSORS} -N 1 -x ${NAME} -f -U ${OUTFOLDER}/"${CONTIGS}"/contigs.fa > >(tee ${NAME}_stdout.log) 2> >(tee ${NAME}_stderr.log >&2) -S ${OUTFOLDER}/"${CONTIGS}"/align_contigs.sam    #bowtie2 -x <ref_base> -U <fq files> -S <output sam>
+        bowtie2 -p ${PROCESSORS} -N 1 -x ${NAME} -f -U ${OUTFOLDER}/"${CONTIGS}"/contigs.fa -S ${OUTFOLDER}/"${CONTIGS}"/align_contigs.sam    #bowtie2 -x <ref_base> -U <fq files> -S <output sam>
 	echo ==== Done Mapping Contigs ====
     fi
 }

--- a/bin/sisrs
+++ b/bin/sisrs
@@ -314,8 +314,9 @@ alignContigs(){
         #Align all species reads against composite genome. N=1 allows a mismatch #x The basename of the index for the reference genome
         bowtie2 -p "${PROCESSORS}" -N 1 --local -x ${OUTFOLDER}/"${CONTIGS}"/contigs -U ${FASTQLIST} | samtools view -Su -@ "${PROCESSORS}" -F 4 - | samtools sort -@ "${PROCESSORS}" - -o ${FOLDER}/${FOLDERNAME}_Temp.bam
         #Extract uniquely mapping reads
-        samtools view -@ 20 -H ${FOLDER}/${FOLDERNAME}_Temp.bam > ${FOLDER}/${FOLDERNAME}_Header.sam
-        samtools view -@ 20 ${FOLDER}/${FOLDERNAME}_Temp.bam | grep -v "XS:" | cat ${FOLDER}/${FOLDERNAME}_Header.sam - | samtools view -@ 20 -b - > ${FOLDER}/${FOLDERNAME}.bam
+        samtools view -@ "${PROCESSORS}" -H ${FOLDER}/${FOLDERNAME}_Temp.bam > ${FOLDER}/${FOLDERNAME}_Header.sam
+        samtools view -@ "${PROCESSORS}" ${FOLDER}/${FOLDERNAME}_Temp.bam | grep -v "XS:" | cat ${FOLDER}/${FOLDERNAME}_Header.sam - | samtools view -@ "${PROCESSORS}" -b - > ${FOLDER}/${FOLDERNAME}.bam
+        #Remove temporary files
         rm ${FOLDER}/${FOLDERNAME}_Temp.bam
         rm ${FOLDER}/${FOLDERNAME}_Header.sam
     done

--- a/bin/sisrs
+++ b/bin/sisrs
@@ -355,9 +355,9 @@ identifyFixedSites(){
 
     #align reads to contigs
     for FOLDER in "${FOLDERLISTA[@]}";do
-        rm *.bam
-        rm *.bai
-        rm *.pileups
+        rm ${FOLDER}/*.bam
+        rm ${FOLDER}/*.bai
+        rm ${FOLDER}/*.pileups
         FASTQ=( $( find ${FOLDER} -name "*fastq" ) )
         FASTQLIST=( $(join_by , "${FASTQ[@]}"))
         FOLDERNAME=( $(echo $(basename ${FOLDER} ) ) )

--- a/bin/sisrs
+++ b/bin/sisrs
@@ -307,12 +307,12 @@ alignContigs(){
 
     #align reads to contigs
     for FOLDER in "${FOLDERLISTA[@]}";do
-    FASTQ=( $( find ${FOLDER} -name "*fastq" ) )
-    FASTQLIST=( $(join_by , "${FASTQ[@]}"))
-    FOLDERNAME=( $(echo $(basename ${FOLDER} ) ) )
-    echo ==== Aligning FILELISTU ${NAME} ====
-    #N=1 allows a mismatch #x The basename of the index for the reference genome
-    bowtie2 -p "${PROCESSORS}" -N 1 --local -x ${OUTFOLDER}/"${CONTIGS}"/contigs -U ${FASTQLIST} | samtools view -Su -@ "${PROCESSORS}" -F 4 - | samtools sort -@ "${PROCESSORS}" - -o ${FOLDERNAME}.bam
+        FASTQ=( $( find ${FOLDER} -name "*fastq" ) )
+        FASTQLIST=( $(join_by , "${FASTQ[@]}"))
+        FOLDERNAME=( $(echo $(basename ${FOLDER} ) ) )
+        echo ==== Aligning FILELISTU ${NAME} ====
+        #N=1 allows a mismatch #x The basename of the index for the reference genome
+        bowtie2 -p "${PROCESSORS}" -N 1 --local -x ${OUTFOLDER}/"${CONTIGS}"/contigs -U ${FASTQLIST} | samtools view -Su -@ "${PROCESSORS}" -F 4 - | samtools sort -@ "${PROCESSORS}" - -o ${FOLDERNAME}.bam
     done
 
     echo ==== Done Aligning ====

--- a/bin/sisrs
+++ b/bin/sisrs
@@ -341,7 +341,7 @@ mapContigs(){
 identifyFixedSites(){
     samtools faidx ${OUTFOLDER}/${CONTIGS}/contigs.fa
 
-    parallel --jobs "${PROCESSORS}" 'samtools mpileup -f' "${OUTFOLDER}"/"${CONTIGS}"/contigs.fa 'echo "$( echo {}/$(basename {} ) )".bam >' 'echo "$( echo {}/$(basename {} ) )".pileups' ::: "${FOLDERLISTA[@]}"
+    parallel --jobs "${PROCESSORS}" 'samtools mpileup -f' "${OUTFOLDER}"/"${CONTIGS}"/contigs.fa "$( echo {}/$(basename {} ) )"'.bam >' "$( echo {}/$(basename {} ) )"'.pileups' ::: "${FOLDERLISTA[@]}"
     parallel --jobs "${PROCESSORS}" "${DIR}/libexec/sisrs/specific_genome.py {} ${OUTFOLDER}/${CONTIGS}/contigs.fa" ::: "${FOLDERLISTA[@]}"
 
     if [[ $? != 0 ]]; then

--- a/bin/sisrs
+++ b/bin/sisrs
@@ -341,7 +341,7 @@ mapContigs(){
 identifyFixedSites(){
     samtools faidx ${OUTFOLDER}/${CONTIGS}/contigs.fa
 
-    parallel --jobs "${PROCESSORS}" 'samtools mpileup -f' "${OUTFOLDER}"/"${CONTIGS}"'/contigs.fa "$( echo {}/$(basename {} ) )".bam ">" "$( echo {}/$(basename {} ) )".pileups' ::: "${FOLDERLISTA[@]}"
+    parallel --jobs "${PROCESSORS}" 'samtools mpileup -f' "${OUTFOLDER}"/"${CONTIGS}"/contigs.fa '"$( echo {}/$(basename {} ) )".bam' '> "$( echo {}/$(basename {} ) )".pileups' ::: "${FOLDERLISTA[@]}"
     parallel --jobs "${PROCESSORS}" "${DIR}/libexec/sisrs/specific_genome.py {} ${OUTFOLDER}/${CONTIGS}/contigs.fa" ::: "${FOLDERLISTA[@]}"
 
     if [[ $? != 0 ]]; then

--- a/bin/sisrs
+++ b/bin/sisrs
@@ -341,7 +341,7 @@ mapContigs(){
 identifyFixedSites(){
     samtools faidx ${OUTFOLDER}/${CONTIGS}/contigs.fa
 
-    parallel --jobs "${PROCESSORS}" 'samtools mpileup -f' "${OUTFOLDER}"/"${CONTIGS}"/contigs.fa "$( echo {}/$(basename {} ) )"'.bam >' "$( echo {}/$(basename {} ) )"'.pileups' ::: "${FOLDERLISTA[@]}"
+    parallel --jobs "${PROCESSORS}" 'samtools mpileup -f' "${OUTFOLDER}"/"${CONTIGS}"/contigs.fa '"$( echo {}/$(basename {} ) )".bam' '"> $( echo {}/$(basename {} ) )"'.pileups ::: "${FOLDERLISTA[@]}"
     parallel --jobs "${PROCESSORS}" "${DIR}/libexec/sisrs/specific_genome.py {} ${OUTFOLDER}/${CONTIGS}/contigs.fa" ::: "${FOLDERLISTA[@]}"
 
     if [[ $? != 0 ]]; then
@@ -368,19 +368,8 @@ identifyFixedSites(){
         rm ${FOLDER}/${FOLDERNAME}_Header.sam
     done
     echo =============DONERAL==================
-    for FILE in "${FILELIST[@]}"; do
-        NAME=$( echo ${FILE} | sed s/${FILEID}// | sed 's/\.[^.]*$//' )
-        echo ==== Aligning FILELIST ${NAME}  ====
-        bowtie2 -p "${PROCESSORS}" -N 1 --local -x $(dirname ${FILE})/contigs -1 ${FILE} -2 $( echo ${FILE}|sed s/${FILEID}/${FILEID2}/ ) > >(tee ${NAME}_stdout.log) 2> >(tee ${NAME}_stderr.log >&2) | samtools view -Su -@ "${PROCESSORS}" -F 4 - | samtools sort -@ "${PROCESSORS}" - -o ${NAME}.bam
-    done
-    for FILE in "${FILELISTU[@]}"; do
-        NAME=$( echo ${FILE} | sed 's/\.[^.]*$//' )
-        echo ==== Aligning FILELISTU ${NAME} ====
-        bowtie2 -p "${PROCESSORS}" -N 1 --local -x $(dirname ${FILE})/contigs -U ${FILE} > >(tee ${NAME}_stdout.log) 2> >(tee ${NAME}_stderr.log >&2) | samtools view -Su -@ "${PROCESSORS}" -F 4 - | samtools sort -@ "${PROCESSORS}" - -o ${NAME}.bam
-    done
 
-    parallel --jobs "${PROCESSORS}" 'samtools index "$( echo {} | sed 's/"${FILEID}"//' | sed s/\.[^.]*$// )".bam' ::: "${FILELIST[@]}"
-
+    parallel --jobs "${PROCESSORS}" 'samtools index "$( echo {}/$(basename {} ) )".bam' ::: "${FOLDERLISTA[@]}"
     parallel --jobs "${PROCESSORS}" 'samtools mpileup -f "$(dirname {})"/contigs.fa "$( echo {} | sed 's/"${FILEID}"//' | sed s/\.[^.]*$// )".bam -A > "$( echo {} | sed 's/"${FILEID}"//' | sed s/\.[^.]*$// )".pileups' ::: "${FILELIST[@]}" "${FILELISTU[@]}"
 
     #put base for each site in a dictionary (allows no variation when calling sites)

--- a/bin/sisrs
+++ b/bin/sisrs
@@ -422,13 +422,13 @@ outputAlignment(){
 }
 
 changeMissing(){
-    if [[ ${MISSING} -lt $((${#FOLDERLISTA[@]} - 2)) ]]; then
-        ${DIR}/libexec/sisrs/filter_nexus_for_missing.py ${OUTFOLDER}/alignment.nex ${MISSING}       #alignment w specified number missing
-    fi
+    ${DIR}/libexec/sisrs/filter_nexus_for_missing.py ${OUTFOLDER}/alignment.nex ${MISSING}       #alignment w specified number missing
     if [[ $? != 0 ]]; then
         echo "filtering for missing failed"
         exit 1
     fi
+    #Clean locs_m*.txt file
+    tr " " "\n" < ${OUTFOLDER}/locs_m${MISSING}.txt > locs_m${MISSING}_newLine.txt
 }
 
 runSISRS(){
@@ -456,8 +456,7 @@ runSISRS(){
 ####################LOCI#######################
 
 copyRefContigs(){
-    grep -oe "SISRS_[^/]*" "${OUTFOLDER}/alignment.nex" | uniq -c | sort -k1 -nr | awk '{print $2}' > "${OUTFOLDER}/loci.txt"
-    parallel --jobs "${PROCESSORS}" "${DIR}/libexec/gfr/get_seq.py" '{}/contigs.fa' "${OUTFOLDER}/loci.txt" '{}/ref_genes.fa'  ::: "${FOLDERLISTA[@]}"
+    parallel --jobs "${PROCESSORS}" "${DIR}/libexec/gfr/get_seq.py" '{}/contigs.fa' "${OUTFOLDER}/locs_m${MISSING}.txt" '{}/ref_genes.fa'  ::: "${FOLDERLISTA[@]}"
 }
 
 fromRefToSpRef(){

--- a/bin/sisrs
+++ b/bin/sisrs
@@ -459,7 +459,7 @@ copyRefContigs(){
   if [[ -e "${OUTFOLDER}/locs_m${MISSING}_Clean.txt" ]];then
     parallel --jobs "${PROCESSORS}" "${DIR}/libexec/gfr/get_seq.py" '{}/contigs.fa' "${OUTFOLDER}/locs_m${MISSING}_Clean.txt" '{}/ref_genes.fa'  ::: "${FOLDERLISTA[@]}"
   else
-    echo locs_m${MISSING}_Clean.txt not found in ${OUTFOLDER}, must first run "sisrs changeMissing -f ${OUTFOLDER} -m {MISSING}-c 0". Aborting...; exit 1;
+    echo locs_m${MISSING}_Clean.txt not found in ${OUTFOLDER}, must first run ""sisrs changeMissing -f ${OUTFOLDER} -m ${MISSING}-c 0"". Aborting...; exit 1;
   fi
 }
 

--- a/bin/sisrs
+++ b/bin/sisrs
@@ -313,7 +313,7 @@ alignContigs(){
     echo ==== Aligning FILELISTU ${NAME} ====
     #N=1 allows a mismatch #x The basename of the index for the reference genome
     bowtie2 -p "${PROCESSORS}" -N 1 --local -x ${OUTFOLDER}/"${CONTIGS}"/contigs -U ${FASTQLIST} | samtools view -Su -@ "${PROCESSORS}" -F 4 - | samtools sort -@ "${PROCESSORS}" - -o ${FOLDERNAME}.bam
-        done
+    done
 
     echo ==== Done Aligning ====
 }

--- a/bin/sisrs
+++ b/bin/sisrs
@@ -459,7 +459,7 @@ copyRefContigs(){
   if [[ -e "${OUTFOLDER}/locs_m${MISSING}_Clean.txt" ]];then
     parallel --jobs "${PROCESSORS}" "${DIR}/libexec/gfr/get_seq.py" '{}/contigs.fa' "${OUTFOLDER}/locs_m${MISSING}_Clean.txt" '{}/ref_genes.fa'  ::: "${FOLDERLISTA[@]}"
   else
-    echo locs_m${MISSING}_Clean.txt not found in ${OUTFOLDER}, must first run \sisrs changeMissing -f ${OUTFOLDER} -m ${MISSING} -c 0\". Aborting...; exit 1;
+    echo locs_m${MISSING}_Clean.txt not found in ${OUTFOLDER}, must first run \"sisrs changeMissing -f ${OUTFOLDER} -m ${MISSING} -c 0\". Aborting...; exit 1;
   fi
 }
 

--- a/bin/sisrs
+++ b/bin/sisrs
@@ -312,7 +312,7 @@ alignContigs(){
         FOLDERNAME=( $(echo $(basename ${FOLDER} ) ) )
         echo ==== Aligning FILELISTU ${NAME} ====
         #N=1 allows a mismatch #x The basename of the index for the reference genome
-        bowtie2 -p "${PROCESSORS}" -N 1 --local -x ${OUTFOLDER}/"${CONTIGS}"/contigs -U ${FASTQLIST} | samtools view -Su -@ "${PROCESSORS}" -F 4 - | samtools sort -@ "${PROCESSORS}" - -o ${FOLDERNAME}.bam
+        bowtie2 -p "${PROCESSORS}" -N 1 --local -x ${OUTFOLDER}/"${CONTIGS}"/contigs -U ${FASTQLIST} | samtools view -Su -@ "${PROCESSORS}" -F 4 - | samtools sort -@ "${PROCESSORS}" - -o ${FOLDER}/${FOLDERNAME}.bam
     done
 
     echo ==== Done Aligning ====

--- a/bin/sisrs
+++ b/bin/sisrs
@@ -428,7 +428,7 @@ changeMissing(){
         exit 1
     fi
     #Clean locs_m*.txt file
-    tr " " "\n" < ${OUTFOLDER}/locs_m${MISSING}.txt > ${OUTFOLDER}/locs_m${MISSING}_newLine.txt
+    tr " " "\n" < ${OUTFOLDER}/locs_m${MISSING}.txt | grep -oe "SISRS_[^/]*" - | uniq -c | sort -k1 -nr | awk '{print $2}' > "${OUTFOLDER}/locs_m${MISSING}_Clean.txt"
 }
 
 runSISRS(){
@@ -456,7 +456,7 @@ runSISRS(){
 ####################LOCI#######################
 
 copyRefContigs(){
-    parallel --jobs "${PROCESSORS}" "${DIR}/libexec/gfr/get_seq.py" '{}/contigs.fa' "${OUTFOLDER}/locs_m${MISSING}.txt" '{}/ref_genes.fa'  ::: "${FOLDERLISTA[@]}"
+    parallel --jobs "${PROCESSORS}" "${DIR}/libexec/gfr/get_seq.py" '{}/contigs.fa' "${OUTFOLDER}/locs_m${MISSING}_Clean.txt" '{}/ref_genes.fa'  ::: "${FOLDERLISTA[@]}"
 }
 
 fromRefToSpRef(){

--- a/bin/sisrs
+++ b/bin/sisrs
@@ -355,9 +355,10 @@ identifyFixedSites(){
 
     #align reads to contigs
     for FOLDER in "${FOLDERLISTA[@]}";do
-        rm ${FOLDER}/*.bam
-        rm ${FOLDER}/*.bai
-        rm ${FOLDER}/*.pileups
+        FOLDERNAME=( $(echo $(basename ${FOLDER} ) ) )
+        rm ${FOLDER}/${FOLDERNAME}.bam
+        rm ${FOLDER}/${FOLDERNAME}.bai
+        rm ${FOLDER}/${FOLDERNAME}.pileups
         FASTQ=( $( find ${FOLDER} -name "*fastq" ) )
         FASTQLIST=( $(join_by , "${FASTQ[@]}"))
         FOLDERNAME=( $(echo $(basename ${FOLDER} ) ) )

--- a/bin/sisrs
+++ b/bin/sisrs
@@ -354,6 +354,9 @@ identifyFixedSites(){
 
     #align reads to contigs
     for FOLDER in "${FOLDERLISTA[@]}";do
+        rm *.bam
+        rm *.bai
+        rm *.pileups
         FASTQ=( $( find ${FOLDER} -name "*fastq" ) )
         FASTQLIST=( $(join_by , "${FASTQ[@]}"))
         FOLDERNAME=( $(echo $(basename ${FOLDER} ) ) )
@@ -367,10 +370,9 @@ identifyFixedSites(){
         rm ${FOLDER}/${FOLDERNAME}_Temp.bam
         rm ${FOLDER}/${FOLDERNAME}_Header.sam
     done
-    echo =============DONERAL==================
 
     parallel --jobs "${PROCESSORS}" 'samtools index "$( echo {}/$(basename {} ) )".bam' ::: "${FOLDERLISTA[@]}"
-    parallel --jobs "${PROCESSORS}" 'samtools mpileup -f "$(dirname {})"/contigs.fa "$( echo {} | sed 's/"${FILEID}"//' | sed s/\.[^.]*$// )".bam -A > "$( echo {} | sed 's/"${FILEID}"//' | sed s/\.[^.]*$// )".pileups' ::: "${FILELIST[@]}" "${FILELISTU[@]}"
+    parallel --jobs "${PROCESSORS}" 'samtools mpileup -f' {}/contigs.fa '"$( echo {}/$(basename {} ) )".bam' '> "$( echo {}/$(basename {} ) )".pileups' ::: "${FOLDERLISTA[@]}"
 
     #put base for each site in a dictionary (allows no variation when calling sites)
     parallel --jobs "${PROCESSORS}" "${DIR}/libexec/sisrs/get_pruned_dict.py {} ${MINREAD} ${THRESHOLD}" ::: "${FOLDERLISTA[@]}"

--- a/bin/sisrs
+++ b/bin/sisrs
@@ -300,9 +300,10 @@ if [[ $ASSEMBLER != "premade" ]];then
             ls ${OUTFOLDER}/subsamples/*fastq | parallel -j ${PROCESSORS} basename > ${OUTFOLDER}/subsamples/minia_read_file.txt
             minia -in ${OUTFOLDER}/subsamples/minia_read_file.txt -kmer-size ${KMER} -nb-cores "${PROCESSORS}" -out ${OUTFOLDER}/miniaoutput/
             mv ${OUTFOLDER}/miniaoutput/.contigs.fa ${OUTFOLDER}/miniaoutput/contigs.fa
+            rm ${OUTFOLDER}/miniaoutput/.h5
         fi
 
-        if [[ $ASSEMBLER == "ABYSS" ]]; then
+        if [[ $ASSEMBLER == "abyss" ]]; then
             mkdir ${OUTFOLDER}/abyssoutput
             ABYSS -k ${KMER} -o ${OUTFOLDER}/abyssoutput/contigs.fa ${OUTFOLDER}/subsamples/*fastq
         fi

--- a/bin/sisrs
+++ b/bin/sisrs
@@ -341,7 +341,7 @@ mapContigs(){
 identifyFixedSites(){
     samtools faidx ${OUTFOLDER}/${CONTIGS}/contigs.fa
 
-    parallel --jobs "${PROCESSORS}" 'samtools mpileup -f' "${OUTFOLDER}"/"${CONTIGS}"/contigs.fa 'echo "$( echo {}/$(basename {} ) )".bam' > 'echo "$( echo {}/$(basename {} ) )".pileups' ::: "${FOLDERLISTA[@]}"
+    parallel --jobs "${PROCESSORS}" 'samtools mpileup -f' "${OUTFOLDER}"/"${CONTIGS}"/contigs.fa 'echo "$( echo {}/$(basename {} ) )".bam >' 'echo "$( echo {}/$(basename {} ) )".pileups' ::: "${FOLDERLISTA[@]}"
     parallel --jobs "${PROCESSORS}" "${DIR}/libexec/sisrs/specific_genome.py {} ${OUTFOLDER}/${CONTIGS}/contigs.fa" ::: "${FOLDERLISTA[@]}"
 
     if [[ $? != 0 ]]; then

--- a/bin/sisrs
+++ b/bin/sisrs
@@ -459,7 +459,7 @@ copyRefContigs(){
   if [[ -e "${OUTFOLDER}/locs_m${MISSING}_Clean.txt" ]];then
     parallel --jobs "${PROCESSORS}" "${DIR}/libexec/gfr/get_seq.py" '{}/contigs.fa' "${OUTFOLDER}/locs_m${MISSING}_Clean.txt" '{}/ref_genes.fa'  ::: "${FOLDERLISTA[@]}"
   else
-    echo locs_m${MISSING}_Clean.txt not found in ${OUTFOLDER}, must first run 'sisrs changeMissing -f ${OUTFOLDER} -m {MISSING}-c 0'. Aborting...; exit 1;
+    echo locs_m${MISSING}_Clean.txt not found in ${OUTFOLDER}, must first run "sisrs changeMissing -f ${OUTFOLDER} -m {MISSING}-c 0". Aborting...; exit 1;
   fi
 }
 

--- a/bin/sisrs
+++ b/bin/sisrs
@@ -341,7 +341,7 @@ mapContigs(){
 identifyFixedSites(){
     samtools faidx ${OUTFOLDER}/${CONTIGS}/contigs.fa
 
-    parallel --jobs "${PROCESSORS}" 'samtools mpileup -f' "${OUTFOLDER}"/"${CONTIGS}"/contigs.fa "$( echo {}/$(basename {} ) )".bam > "$( echo {}/$(basename {} ) )".pileups ::: "${FOLDERLISTA[@]}" "${FOLDERLISTA[@]}"
+    parallel --jobs "${PROCESSORS}" 'samtools mpileup -f' "${OUTFOLDER}"/"${CONTIGS}"/contigs.fa "$( echo {}/$(basename {} ) )".bam > "echo $( echo {}/$(basename {} ) )".pileups ::: "${FOLDERLISTA[@]}" "${FOLDERLISTA[@]}" "${FOLDERLISTA[@]}" "${FOLDERLISTA[@]}"
     parallel --jobs "${PROCESSORS}" "${DIR}/libexec/sisrs/specific_genome.py {} ${OUTFOLDER}/${CONTIGS}/contigs.fa" ::: "${FOLDERLISTA[@]}"
 
     if [[ $? != 0 ]]; then

--- a/bin/sisrs
+++ b/bin/sisrs
@@ -163,6 +163,8 @@ which samtools &>/dev/null
 [ $? -eq 0 ] || { echo "Samtools v1 or greater must be installed to run SISRS. The installation folder must be in your path. Aborting."; exit 1; }
 [[ $(samtools --version-only| cut -c1) -ge 1 ]] || { echo "Samtools v1 or greater must be installed to run SISRS. The installation folder must be in your path. Aborting."; exit 1; }
 
+function join_by { local IFS="$1"; shift; echo "$*"; }
+
 ###########Link Outfolder##############
 
 if [[ "${MAINFOLDER}" = "${OUTFOLDER}" ]] || [[ -z $OUTFOLDER ]]; then     #Check if data folder and output folder are the same
@@ -303,7 +305,6 @@ fi
 
 alignContigs(){
     bowtie2-build ${OUTFOLDER}/"${CONTIGS}"/contigs.fa ${OUTFOLDER}/"${CONTIGS}"/contigs      #index contigs
-    function join_by { local IFS="$1"; shift; echo "$*"; }
 
     #Find all FASTQ files in each species folder
     for FOLDER in "${FOLDERLISTA[@]}";do

--- a/bin/sisrs
+++ b/bin/sisrs
@@ -310,7 +310,7 @@ alignContigs(){
         FASTQ=( $( find ${FOLDER} -name "*fastq" ) )
         FASTQLIST=( $(join_by , "${FASTQ[@]}"))
         FOLDERNAME=( $(echo $(basename ${FOLDER} ) ) )
-        echo ==== Aligning FILELISTU ${NAME} ====
+        echo ==== Aligning ${FOLDERNAME} as Single-Ended ====
         #N=1 allows a mismatch #x The basename of the index for the reference genome
         bowtie2 -p "${PROCESSORS}" -N 1 --local -x ${OUTFOLDER}/"${CONTIGS}"/contigs -U ${FASTQLIST} | samtools view -Su -@ "${PROCESSORS}" -F 4 - | samtools sort -@ "${PROCESSORS}" - -o ${FOLDER}/${FOLDERNAME}.bam
     done

--- a/bin/sisrs
+++ b/bin/sisrs
@@ -341,7 +341,7 @@ mapContigs(){
 identifyFixedSites(){
     samtools faidx ${OUTFOLDER}/${CONTIGS}/contigs.fa
 
-    parallel --jobs "${PROCESSORS}" 'samtools mpileup -f' "${OUTFOLDER}"/"${CONTIGS}"/contigs.fa '"$( echo {}/$(basename {} ) )".bam' '"> $( echo {}/$(basename {} ) )"'.pileups ::: "${FOLDERLISTA[@]}"
+    parallel --jobs "${PROCESSORS}" 'samtools mpileup -f "${OUTFOLDER}"/"${CONTIGS}"/contigs.fa "$( echo {}/$(basename {} ) )".bam ">" "$( echo {}/$(basename {} ) )".pileups' ::: "${FOLDERLISTA[@]}"
     parallel --jobs "${PROCESSORS}" "${DIR}/libexec/sisrs/specific_genome.py {} ${OUTFOLDER}/${CONTIGS}/contigs.fa" ::: "${FOLDERLISTA[@]}"
 
     if [[ $? != 0 ]]; then

--- a/bin/sisrs
+++ b/bin/sisrs
@@ -308,6 +308,8 @@ if [[ $ASSEMBLER != "premade" ]];then
 fi
 
 alignContigs(){
+    mv ${OUTFOLDER}/${CONTIGS}/contigs.fa ${OUTFOLDER}/${CONTIGS}/contigs_OriginalNames.fa
+    rename.sh in=${OUTFOLDER}/${CONTIGS}/contigs_OriginalNames.fa out=${OUTFOLDER}/${CONTIGS}/contigs.fa prefix=SISRS addprefix=t
     bowtie2-build ${OUTFOLDER}/"${CONTIGS}"/contigs.fa ${OUTFOLDER}/"${CONTIGS}"/contigs      #index contigs
 
     #Find all FASTQ files in each species folder

--- a/bin/sisrs
+++ b/bin/sisrs
@@ -428,7 +428,7 @@ changeMissing(){
         exit 1
     fi
     #Clean locs_m*.txt file
-    tr " " "\n" < ${OUTFOLDER}/locs_m${MISSING}.txt > locs_m${MISSING}_newLine.txt
+    tr " " "\n" < ${OUTFOLDER}/locs_m${MISSING}.txt > ${OUTFOLDER}/locs_m${MISSING}_newLine.txt
 }
 
 runSISRS(){

--- a/bin/sisrs
+++ b/bin/sisrs
@@ -303,20 +303,18 @@ fi
 
 alignContigs(){
     bowtie2-build ${OUTFOLDER}/"${CONTIGS}"/contigs.fa ${OUTFOLDER}/"${CONTIGS}"/contigs      #index contigs
+    function join_by { local IFS="$1"; shift; echo "$*"; }
 
     #align reads to contigs
-    for FILE in "${FILELIST[@]}"; do
-        NAME=$( echo ${FILE} | sed s/${FILEID}// | sed 's/\.[^.]*$//' ) #includes folder but not the read or the extension
-        echo ==== Aligning FILELIST ${NAME}  ====
-        #N=1 allows a mismatch #x The basename of the index for the reference genome
-        bowtie2 -p "${PROCESSORS}" -N 1 --local -x ${OUTFOLDER}/"${CONTIGS}"/contigs -1 ${FILE} -2 $( echo ${FILE}|sed s/${FILEID}/${FILEID2}/ ) > >(tee ${NAME}_stdout.log) 2> >(tee ${NAME}_stderr.log >&2) | samtools view -Su -@ "${PROCESSORS}" -F 4 - | samtools sort -@ "${PROCESSORS}" - -o ${NAME}.bam
-    done
-    for FILE in "${FILELISTU[@]}"; do
-        NAME=$( echo ${FILE} | sed 's/\.[^.]*$//' ) #includes folder but not the read or the extension
-        echo ==== Aligning FILELISTU ${NAME} ====
-        #N=1 allows a mismatch #x The basename of the index for the reference genome
-        bowtie2 -p "${PROCESSORS}" -N 1 --local -x ${OUTFOLDER}/"${CONTIGS}"/contigs -U ${FILE} > >(tee ${NAME}_stdout.log) 2> >(tee ${NAME}_stderr.log >&2) | samtools view -Su -@ "${PROCESSORS}" -F 4 - | samtools sort -@ "${PROCESSORS}" - -o ${NAME}.bam
-    done
+    for FOLDER in "${FOLDERLISTA[@]}";do
+    FASTQ=( $( find ${FOLDER} -name "*fastq" ) )
+    FASTQLIST=( $(join_by , "${FASTQ[@]}"))
+    FOLDERNAME=( $(echo $(basename ${FOLDER} ) ) )
+    echo ==== Aligning FILELISTU ${NAME} ====
+    #N=1 allows a mismatch #x The basename of the index for the reference genome
+    bowtie2 -p "${PROCESSORS}" -N 1 --local -x ${OUTFOLDER}/"${CONTIGS}"/contigs -U ${FASTQLIST} | samtools view -Su -@ "${PROCESSORS}" -F 4 - | samtools sort -@ "${PROCESSORS}" - -o ${FOLDERNAME}.bam
+        done
+
     echo ==== Done Aligning ====
 }
 

--- a/bin/sisrs
+++ b/bin/sisrs
@@ -229,7 +229,7 @@ if [[ $ASSEMBLER == "premade" ]];then
     }
 fi
 
-if [[ $ASSEMBLER !="premade" ]];then
+if [[ $ASSEMBLER != "premade" ]];then
     subSample(){
         if [ -z $GENOMESIZE ]; then
             echo "You must enter the approximate size of the genome / transcriptome. For more information run sisrs -h"

--- a/bin/sisrs
+++ b/bin/sisrs
@@ -69,8 +69,8 @@ Flags:
  -l : the number of alleles
  -a : assembler (velvet, minia, abyss, or premade)
       -If using a premade composite genome, it must be in a folder named
-      'premade' in the same directory as the folders of read data, and
-      must be called 'contigs.fa'
+      'premadeoutput' in the same directory as the folders of read data,
+      and must be called 'contigs.fa'
 
  Example command:
  sisrs sites -g 1745690 -p 40 -m 4 -f /usr/test_data

--- a/bin/sisrs
+++ b/bin/sisrs
@@ -367,7 +367,7 @@ identifyFixedSites(){
     for FOLDER in "${FOLDERLISTA[@]}";do
         FOLDERNAME=( $(echo $(basename ${FOLDER} ) ) )
         rm ${FOLDER}/${FOLDERNAME}.bam
-        rm ${FOLDER}/${FOLDERNAME}.bai
+        rm ${FOLDER}/${FOLDERNAME}.bam.bai
         rm ${FOLDER}/${FOLDERNAME}.pileups
         FASTQ=( $( find ${FOLDER} -name "*fastq" ) )
         FASTQLIST=( $(join_by , "${FASTQ[@]}"))

--- a/bin/sisrs
+++ b/bin/sisrs
@@ -310,8 +310,10 @@ if [[ $ASSEMBLER != "premade" ]];then
 fi
 
 alignContigs(){
+    echo ==== Renaming Scaffolds for SISRS ====
     mv ${OUTFOLDER}/${CONTIGS}/contigs.fa ${OUTFOLDER}/${CONTIGS}/contigs_OriginalNames.fa
     rename.sh in=${OUTFOLDER}/${CONTIGS}/contigs_OriginalNames.fa out=${OUTFOLDER}/${CONTIGS}/contigs.fa prefix=SISRS addprefix=t
+    echo ==== Scafolds Renamed ====
     bowtie2-build ${OUTFOLDER}/"${CONTIGS}"/contigs.fa ${OUTFOLDER}/"${CONTIGS}"/contigs      #index contigs
 
     #Find all FASTQ files in each species folder

--- a/bin/sisrs
+++ b/bin/sisrs
@@ -87,7 +87,6 @@ KMER=21
 MINREAD=3
 PROCESSORS=1
 MAINFOLDER=$( echo "$(pwd)")
-OUTFOLDER=$( echo "$(pwd)")
 THRESHOLD=1
 ALLELES=1
 DEBUG=0
@@ -166,7 +165,7 @@ which samtools &>/dev/null
 
 ###########Link Outfolder##############
 
-if [[ "${MAINFOLDER}" = "${OUTFOLDER}" ]]; then     #Check if data folder and output folder are the same
+if [[ "${MAINFOLDER}" = "${OUTFOLDER}" ]] || [[ -z $OUTFOLDER ]]; then     #Check if data folder and output folder are the same
     echo "Note: SISRS writing into data folder"
     OUTFOLDER="${MAINFOLDER}"
 

--- a/bin/sisrs
+++ b/bin/sisrs
@@ -341,7 +341,7 @@ mapContigs(){
 identifyFixedSites(){
     samtools faidx ${OUTFOLDER}/${CONTIGS}/contigs.fa
 
-    parallel --jobs "${PROCESSORS}" 'samtools mpileup -f "${OUTFOLDER}"/"${CONTIGS}"/contigs.fa "$( echo {}/$(basename {} ) )".bam ">" "$( echo {}/$(basename {} ) )".pileups' ::: "${FOLDERLISTA[@]}"
+    parallel --jobs "${PROCESSORS}" 'samtools mpileup -f' "${OUTFOLDER}"/"${CONTIGS}"'/contigs.fa "$( echo {}/$(basename {} ) )".bam ">" "$( echo {}/$(basename {} ) )".pileups' ::: "${FOLDERLISTA[@]}"
     parallel --jobs "${PROCESSORS}" "${DIR}/libexec/sisrs/specific_genome.py {} ${OUTFOLDER}/${CONTIGS}/contigs.fa" ::: "${FOLDERLISTA[@]}"
 
     if [[ $? != 0 ]]; then

--- a/bin/sisrs
+++ b/bin/sisrs
@@ -305,14 +305,19 @@ alignContigs(){
     bowtie2-build ${OUTFOLDER}/"${CONTIGS}"/contigs.fa ${OUTFOLDER}/"${CONTIGS}"/contigs      #index contigs
     function join_by { local IFS="$1"; shift; echo "$*"; }
 
-    #align reads to contigs
+    #Find all FASTQ files in each species folder
     for FOLDER in "${FOLDERLISTA[@]}";do
         FASTQ=( $( find ${FOLDER} -name "*fastq" ) )
         FASTQLIST=( $(join_by , "${FASTQ[@]}"))
         FOLDERNAME=( $(echo $(basename ${FOLDER} ) ) )
         echo ==== Aligning ${FOLDERNAME} as Single-Ended ====
-        #N=1 allows a mismatch #x The basename of the index for the reference genome
-        bowtie2 -p "${PROCESSORS}" -N 1 --local -x ${OUTFOLDER}/"${CONTIGS}"/contigs -U ${FASTQLIST} | samtools view -Su -@ "${PROCESSORS}" -F 4 - | samtools sort -@ "${PROCESSORS}" - -o ${FOLDER}/${FOLDERNAME}.bam
+        #Align all species reads against composite genome. N=1 allows a mismatch #x The basename of the index for the reference genome
+        bowtie2 -p "${PROCESSORS}" -N 1 --local -x ${OUTFOLDER}/"${CONTIGS}"/contigs -U ${FASTQLIST} | samtools view -Su -@ "${PROCESSORS}" -F 4 - | samtools sort -@ "${PROCESSORS}" - -o ${FOLDER}/${FOLDERNAME}_Temp.bam
+        #Extract uniquely mapping reads
+        samtools view -@ 20 -H ${FOLDER}/${FOLDERNAME}_Temp.bam > ${FOLDER}/${FOLDERNAME}_Header.sam
+        samtools view -@ 20 ${FOLDER}/${FOLDERNAME}_Temp.bam | grep -v "XS:" | cat ${FOLDER}/${FOLDERNAME}_Header.sam - | samtools view -@ 20 -b - > ${FOLDER}/${FOLDERNAME}.bam
+        rm ${FOLDER}/${FOLDERNAME}_Temp.bam
+        rm ${FOLDER}/${FOLDERNAME}_Header.sam
     done
 
     echo ==== Done Aligning ====

--- a/bin/sisrs
+++ b/bin/sisrs
@@ -371,7 +371,6 @@ identifyFixedSites(){
         rm ${FOLDER}/${FOLDERNAME}.pileups
         FASTQ=( $( find ${FOLDER} -name "*fastq" ) )
         FASTQLIST=( $(join_by , "${FASTQ[@]}"))
-        FOLDERNAME=( $(echo $(basename ${FOLDER} ) ) )
         echo ==== Aligning ${FOLDERNAME} as Single-Ended ====
         #Align all species reads against composite genome. N=1 allows a mismatch #x The basename of the index for the reference genome
         bowtie2 -p "${PROCESSORS}" -N 1 --local -x ${FOLDER}/contigs -U ${FASTQLIST} | samtools view -Su -@ "${PROCESSORS}" -F 4 - | samtools sort -@ "${PROCESSORS}" - -o ${FOLDER}/${FOLDERNAME}_Temp.bam
@@ -438,7 +437,7 @@ runSISRS(){
 ####################LOCI#######################
 
 copyRefContigs(){
-    grep -oe "[A-Z]*_*[0-9]*_*len[^/]*" "${OUTFOLDER}/alignment.nex" | uniq -c | sort -k1 -nr | awk '{print $2}' > "${OUTFOLDER}/loci.txt"
+    grep -oe "SISRS_[^/]*" "${OUTFOLDER}/alignment.nex" | uniq -c | sort -k1 -nr | awk '{print $2}' > "${OUTFOLDER}/loci.txt"
     parallel --jobs "${PROCESSORS}" "${DIR}/libexec/gfr/get_seq.py" '{}/contigs.fa' "${OUTFOLDER}/loci.txt" '{}/ref_genes.fa'  ::: "${FOLDERLISTA[@]}"
 }
 
@@ -447,21 +446,29 @@ fromRefToSpRef(){
     bowtie2-build ${OUTFOLDER}/ref_genes.fa ${OUTFOLDER}/ref_genes      #index
 
     #align reads to contigs
-    for FILE in "${FILELIST[@]}"; do
-        NAME=$( echo ${FILE} | sed s/${FILEID}// | sed 's/\.[^.]*$//' ) #includes folder but not the read or the extension
-        echo ==== Aligning FILELIST ${NAME}  ====
-        #N=1 allows a mismatch #x The basename of the index for the reference genome
-        bowtie2 -p "${PROCESSORS}" -N 1 --local -x ${OUTFOLDER}/ref_genes -1 ${FILE} -2 $( echo ${FILE}|sed s/${FILEID}/${FILEID2}/ ) > >(tee ${NAME}_stdout.log) 2> >(tee ${NAME}_stderr.log >&2) | samtools -@ "${PROCESSORS}" view -Su -F 4 - | samtools sort -@ "${PROCESSORS}"- -o ${NAME}.bam
-    done
-    for FILE in "${FILELISTU[@]}"; do
-        NAME=$( echo ${FILE} | sed 's/\.[^.]*$//' ) #includes folder but not the read or the extension
-        echo ==== Aligning FILELISTU ${NAME} ====
-        #N=1 allows a mismatch #x The basename of the index for the reference genome
-        bowtie2 -p "${PROCESSORS}" -N 1 --local -x ${OUTFOLDER}/ref_genes -U ${FILE} > >(tee ${NAME}_stdout.log) 2> >(tee ${NAME}_stderr.log >&2) | samtools view -Su -@ "${PROCESSORS}" -F 4 - | samtools sort -@ "${PROCESSORS}" - -o ${NAME}.bam
+    for FOLDER in "${FOLDERLISTA[@]}";do
+        FOLDERNAME=( $(echo $(basename ${FOLDER} ) ) )
+        mv ${FOLDER}/${FOLDERNAME}.bam > ${FOLDER}/${FOLDERNAME}.bam_sites
+        mv ${FOLDER}/${FOLDERNAME}.bam.bai > ${FOLDER}/${FOLDERNAME}.bam.bai_sites
+        mv ${FOLDER}/${FOLDERNAME}.pileups > ${FOLDER}/${FOLDERNAME}.pileups_sites
+        FASTQ=( $( find ${FOLDER} -name "*fastq" ) )
+        FASTQLIST=( $(join_by , "${FASTQ[@]}"))
+        echo ==== Aligning ${FOLDERNAME} as Single-Ended ====
+        #Align all species reads against composite genome. N=1 allows a mismatch #x The basename of the index for the reference genome
+        bowtie2 -p "${PROCESSORS}" -N 1 --local -x ${OUTFOLDER}/ref_genes -U ${FASTQLIST} | samtools view -Su -@ "${PROCESSORS}" -F 4 - | samtools sort -@ "${PROCESSORS}" - -o ${FOLDER}/${FOLDERNAME}_Temp.bam
+        #Extract uniquely mapping reads
+        samtools view -@ "${PROCESSORS}" -H ${FOLDER}/${FOLDERNAME}_Temp.bam > ${FOLDER}/${FOLDERNAME}_Header.sam
+        samtools view -@ "${PROCESSORS}" ${FOLDER}/${FOLDERNAME}_Temp.bam | grep -v "XS:" | cat ${FOLDER}/${FOLDERNAME}_Header.sam - | samtools view -@ "${PROCESSORS}" -b - > ${FOLDER}/${FOLDERNAME}.bam
+        #Remove temporary files
+        rm ${FOLDER}/${FOLDERNAME}_Temp.bam
+        rm ${FOLDER}/${FOLDERNAME}_Header.sam
     done
 
     samtools faidx ${OUTFOLDER}/ref_genes.fa
-    parallel --jobs "${PROCESSORS}" "samtools mpileup -f ${OUTFOLDER}/ref_genes.fa" '$( echo {} | sed s/${FILEID}// | sed 's/\.[^.]*$//' ).bam -A > $( echo {} | sed s/${FILEID}// | sed 's/\.[^.]*$//' ).pileups' ::: "${FILELIST[@]}" "${FILELISTU[@]}"
+
+    parallel --jobs "${PROCESSORS}" 'samtools index "$( echo {}/$(basename {} ) )".bam' ::: "${FOLDERLISTA[@]}"
+    parallel --jobs "${PROCESSORS}" 'samtools mpileup -f' ${OUTFOLDER}/ref_genes.fa '"$( echo {}/$(basename {} ) )".bam' '> "$( echo {}/$(basename {} ) )".pileups' ::: "${FOLDERLISTA[@]}"
+
     parallel --jobs "${PROCESSORS}" "${DIR}/libexec/sisrs/specific_genome.py" {} ${OUTFOLDER}/ref_genes.fa ::: "${FOLDERLISTA[@]}"
 
     parallel --jobs "${PROCESSORS}" mv {}/contigs.fa {}/ref_genes.fa  ::: "${FOLDERLISTA[@]}"
@@ -471,18 +478,19 @@ gfr_aligntoConservedContigs(){
     parallel --jobs "${PROCESSORS}" bowtie2-build '{}/ref_genes.fa {}/ref_genes' ::: "${FOLDERLISTA[@]}"   #build index for conserved contigs
     find "${OUTFOLDER}"/*_loci/ -type f -name '*bam' | parallel -j "${PROCESSORS}" rm -f {}    #delete old bam
 
-    for FOLDER in "${FOLDERLIST[@]}"; do
-        for FILE in "${FOLDER}"/*${FILEID}*fastq; do
-	    # output sorted bam file w/o unaligned reads - lots per folder
-            echo Aligning ${FILE} to conserved contigs
-	    bowtie2 -p "${PROCESSORS}" -N 1 --local -x "${FOLDER}"/ref_genes -1 ${FILE} -2 $( echo ${FILE}|sed s/${FILEID}/${FILEID2}/ ) > >(tee ${FILE/.fastq/}_stdout.log) 2> >(tee ${FILE/.fastq/}_stderr.log >&2) | samtools view -Su -@ "${PROCESSORS}" -F 4 - | samtools sort -@ "${PROCESSORS}" - -o "$FOLDER"_loci/$(basename ${FILE/.fastq}).bam
-        done
-    done
-
-    for FOLDER in "${FOLDERLISTU[@]}"; do
-        for FILE in "${FOLDER}"/*reads*fastq; do
-            bowtie2 -p "${PROCESSORS}" -N 1 --local -x "${FOLDER}"/ref_genes -U ${FILE} > >(tee ${FILE/.fastq/}_stdout.log) 2> >(tee ${FILE/.fastq/}_stderr.log >&2) | samtools view -Su -@ "${PROCESSORS}" -F 4 - | samtools sort -@ "${PROCESSORS}" - -o "$FOLDER"_loci/$(basename ${FILE/.fastq}).bam
-        done
+    for FOLDER in "${FOLDERLISTA[@]}";do
+        FOLDERNAME=( $(echo $(basename ${FOLDER} ) ) )
+        FASTQ=( $( find ${FOLDER} -name "*fastq" ) )
+        FASTQLIST=( $(join_by , "${FASTQ[@]}"))
+        echo ==== Aligning ${FOLDERNAME} to Conserved Contigs ====
+        #Align all species reads against composite genome. N=1 allows a mismatch #x The basename of the index for the reference genome
+        bowtie2 -p "${PROCESSORS}" -N 1 --local -x ${FOLDER}/ref_genes -U ${FASTQLIST} | samtools view -Su -@ "${PROCESSORS}" -F 4 - | samtools sort -@ "${PROCESSORS}" - -o ${FOLDER}_loci/${FOLDERNAME}_Temp.bam
+        #Extract uniquely mapping reads
+        samtools view -@ "${PROCESSORS}" -H ${FOLDER}_loci/${FOLDERNAME}_Temp.bam > ${FOLDER}_loci/${FOLDERNAME}_Header.sam
+        samtools view -@ "${PROCESSORS}" ${FOLDER}_loci/${FOLDERNAME}_Temp.bam | grep -v "XS:" | cat ${FOLDER}_loci/${FOLDERNAME}_Header.sam - | samtools view -@ "${PROCESSORS}" -b - > ${FOLDER}_loci/${FOLDERNAME}.bam
+        #Remove temporary files
+        rm ${FOLDER}_loci/${FOLDERNAME}_Temp.bam
+        rm ${FOLDER}_loci/${FOLDERNAME}_Header.sam
     done
 }
 

--- a/bin/sisrs
+++ b/bin/sisrs
@@ -222,8 +222,8 @@ if [ -z "$MISSING" ]; then MISSING=$((${#FOLDERLISTA[@]} - 2)); fi    #minimum o
 
 ##############################
 if [[ $ASSEMBLER == "premade" ]];then
-    subSample(){echo "No subsampling necessary, using pre-assembled composite genome in ${CONTIGS}, continuing..."}
-    buildContigs(){echo "No contig building necessary, using pre-assembled composite genome in ${CONTIGS}, continuing..."}
+    subSample(){ echo "No subsampling necessary, using pre-assembled composite genome in ${CONTIGS}, continuing..." }
+    buildContigs(){ echo "No contig building necessary, using pre-assembled composite genome in ${CONTIGS}, continuing..." }
 else
     subSample(){
         if [ -z $GENOMESIZE ]; then


### PR DESCRIPTION
Hello SISRS Team,

I made some adjustments to SISRS and things are running fine on my end. Changes include:

1) Added an option to include an output directory (-z). Raw data is symbolically copied into this directory and SISRS runs as normal, but the raw data folder is unchanged. Default behavior remains, as if -z is not set, output goes to MAINFOLDER.

2) Added an assembler option for premade composite genomes (-a premade). This allows users to manipulate their reads and genomes however they wish, and then run SISRS starting from the read mapping step. Useful for very large datasets. File should be named 'contigs.fa', and placed in the MAINFOLDER in a subfolder called 'premadeoutput'.

3) Composite genomes now get a 'SISRS_' prefix attached to each scaffold, which allows for assembler-independent fetching downstream. 

4) Changed all bowtie mapping steps to single-ended mode, and only retained uniquely mapping reads. There are various biological reasons that this is appropriate. 

5) Changed README to include these changes, as well as noting which versions of programs (assembler, samtools) have been validated as working. 
