### PR TITLE
Pull Request: Finished editing pileup file scripts

### DIFF
--- a/libexec/sisrs/get_pruned_dict.py
+++ b/libexec/sisrs/get_pruned_dict.py
@@ -86,6 +86,10 @@ if __name__ == "__main__":
     thresh=float(sys.argv[3])
 
     allbases=getallbases(path)      #dictionary of combined pileups - locus/pos:bases(as list)
+    if len(allbases)==0:
+        print 'No data for '+path
+        sys.exit(1)      #dictionary of combined pileups - locus/pos:bases(as list)
+        
     for pos in allbases:
         base = determine_base(allbases[pos],minread,thresh)     #determine if sufficient data and threshold met for calling allele
         if base is 'D':

--- a/libexec/sisrs/get_pruned_dict.py
+++ b/libexec/sisrs/get_pruned_dict.py
@@ -6,7 +6,7 @@
         path: folder containing mpileup files ending in pileups
         minread: number of reads at a position required to call a base
         thresh: proportion of reads that must be one base for calling to occur
-        
+
     output:
         path/pruned_dict.pkl : contains pickled dictionary of position:base
 
@@ -43,7 +43,7 @@ def getallbases(path):
                 else:
                     allbases[loc]=bases2
         filein.close()
-    
+
     return allbases
 
 #prune by whether there's enough info and species are fixed
@@ -56,7 +56,7 @@ def determine_base(bases,minread,thresh):
             base=counts[0][0]
         else:
             base='N'
-                
+
     return base
 
 def remove_extra(base_str):
@@ -76,27 +76,28 @@ def remove_extra(base_str):
         elif b[0]=='^':                        #skip read qual noted at end of read
             continue
     new_base_list = [i for i in new_base_list if i in bases]    #filter unknown bases
-    
+
     return new_base_list        #list of individual bases
 
 def test_remove_extra(teststring,outstring):
     o = remove_extra(teststring)
     assert o == list(outstring), 'Test failure: result is '+"".join(o)+' not '+outstring
-    
+
 ###############################################
-path=sys.argv[1]
-minread=int(sys.argv[2])
-thresh=float(sys.argv[3])
+if __name__ == "__main__":
+    path=sys.argv[1]
+    minread=int(sys.argv[2])
+    thresh=float(sys.argv[3])
 
-test_remove_extra('A+1CAAA-10*******AAA^--1*AA-2CAA-2**A-2***'.replace('*','D'),'AAAAAAAAD')
+    test_remove_extra('A+1CAAA-10*******AAA^--1*AA-2CAA-2**A-2***'.replace('*','D'),'AAAAAAAAD')
 
-allbases=getallbases(path)      #dictionary of combined pileups - locus/pos:bases(as list)
-for pos in allbases:
-    base = determine_base(allbases[pos],minread,thresh)     #determine if sufficient data and threshold met for calling allele
-    if base is 'D':
-        base='-'
-    allbases[pos] = base
+    allbases=getallbases(path)      #dictionary of combined pileups - locus/pos:bases(as list)
+    for pos in allbases:
+        base = determine_base(allbases[pos],minread,thresh)     #determine if sufficient data and threshold met for calling allele
+        if base is 'D':
+            base='-'
+        allbases[pos] = base
 
-output = open(path+'/pruned_dict.pkl', 'wb')
-cPickle.dump(allbases, output, cPickle.HIGHEST_PROTOCOL)
-output.close()
+    output = open(path+'/pruned_dict.pkl', 'wb')
+    cPickle.dump(allbases, output, cPickle.HIGHEST_PROTOCOL)
+    output.close()

--- a/libexec/sisrs/get_pruned_dict.py
+++ b/libexec/sisrs/get_pruned_dict.py
@@ -18,6 +18,7 @@ from collections import Counter
 import glob
 import string
 import re
+from specific_genome import getCleanList
 
 #get combined pileup info
 def getallbases(path,minread,thresh):
@@ -50,37 +51,6 @@ def getallbases(path,minread,thresh):
                     allbases[loc]=finalBase
 
     return allbases
-
-def getCleanList(ref,bases):
-    bases=bases.replace('.',ref) #insert ref base
-    bases=bases.replace(',',ref)
-    bases=bases.upper() #everything in uppercase
-    bases=list(bases)
-
-    okbases=['A','C','G','T','*']
-    indels=['+','-']
-
-    new_base_list=[]
-    ibase_list = iter(bases)
-    for b in ibase_list:
-        if b in okbases:
-            new_base_list.append(b)     #Get base
-        elif b in indels:                   #skip indels
-            i = int(ibase_list.next())
-            j = str(ibase_list.next())
-            if str.isdigit(j):
-                skip=int(str(i)+j)
-                while skip>0:
-                    z=ibase_list.next()
-                    skip=skip-1
-            else:
-                while i>1:
-                    z=ibase_list.next()
-                    i = i-1
-        elif b=='^':                        #skip read qual noted at end of read
-            z=ibase_list.next()
-
-    return new_base_list
 
 ###############################################
 if __name__ == "__main__":

--- a/libexec/sisrs/get_pruned_dict.py
+++ b/libexec/sisrs/get_pruned_dict.py
@@ -18,6 +18,7 @@ from collections import Counter
 import glob
 import string
 import re
+import os
 from specific_genome import getCleanList
 
 #get combined pileup info

--- a/libexec/sisrs/get_pruned_dict.py
+++ b/libexec/sisrs/get_pruned_dict.py
@@ -33,7 +33,7 @@ def getallbases(path,minread,thresh):
                 cleanBases=getCleanList(ref,bases)  #Get clean bases where * replaced with -
                 assert len(cleanBases) == int(num), 'bases are being counted incorrectly: '+ str(bases) + ' should have '+str(num)+' bases, but it is being converted to '+"".join(cleanBases)
                 finalBase=getFinalBase_Pruned(cleanBases,minread,thresh)
-                if finalBase != 'N':
+                if finalBase != 'N':    #Do not pass Ns to pruned_dictionary, but do pass - as deletion
                     allbases[loc]=finalBase
     return allbases
 

--- a/libexec/sisrs/get_pruned_dict.py
+++ b/libexec/sisrs/get_pruned_dict.py
@@ -79,17 +79,11 @@ def remove_extra(base_str):
 
     return new_base_list        #list of individual bases
 
-def test_remove_extra(teststring,outstring):
-    o = remove_extra(teststring)
-    assert o == list(outstring), 'Test failure: result is '+"".join(o)+' not '+outstring
-
 ###############################################
 if __name__ == "__main__":
     path=sys.argv[1]
     minread=int(sys.argv[2])
     thresh=float(sys.argv[3])
-
-    test_remove_extra('A+1CAAA-10*******AAA^--1*AA-2CAA-2**A-2***'.replace('*','D'),'AAAAAAAAD')
 
     allbases=getallbases(path)      #dictionary of combined pileups - locus/pos:bases(as list)
     for pos in allbases:

--- a/libexec/sisrs/get_pruned_dict.py
+++ b/libexec/sisrs/get_pruned_dict.py
@@ -43,15 +43,12 @@ def getFinalBase_Pruned(cleanBases,bases,minread,thresh):
         singleBase == '-'
     counts=int((Counter(cleanBases).most_common()[0][1]))
 
-    if counts < minread:
-        finalBase='N'
-    else:
+    if counts >= minread and counts/float(len(bases)) >= thresh:
         finalBase=singleBase
+    else:
+        finalBase='N'
 
-    if counts / float(len(bases)) >= thresh:
-        finalBase=singleBase
-    else:
-        finalBase='N'
+    return finalBase
 ###############################################
 if __name__ == "__main__":
     path=sys.argv[1]

--- a/libexec/sisrs/get_pruned_dict.py
+++ b/libexec/sisrs/get_pruned_dict.py
@@ -38,7 +38,7 @@ def getallbases(path,minread,thresh):
     return allbases
 
 def getFinalBase_Pruned(cleanBases,minread,thresh):
-    singleBase=(Counter(cleanBases).most_common()[0][0])
+    singleBase=str((Counter(cleanBases).most_common()[0][0]))
     if singleBase == '*':
         singleBase == '-'
     counts=int((Counter(cleanBases).most_common()[0][1]))

--- a/libexec/sisrs/get_pruned_dict.py
+++ b/libexec/sisrs/get_pruned_dict.py
@@ -32,12 +32,12 @@ def getallbases(path,minread,thresh):
                 loc=node+'/'+pos
                 cleanBases=getCleanList(ref,bases)  #Get clean bases where * replaced with -
                 assert len(cleanBases) == int(num), 'bases are being counted incorrectly: '+ str(bases) + ' should have '+str(num)+' bases, but it is being converted to '+"".join(cleanBases)
-                finalBase=getfinalbase(cleanBases,bases,minread,thresh)
+                finalBase=getFinalBase_Pruned(cleanBases,bases,minread,thresh)
                 if finalBase not 'N':
                     allbases[loc]=finalBase
     return allbases
 
-def getfinalbase(cleanBases,bases,minread,thresh):
+def getFinalBase_Pruned(cleanBases,bases,minread,thresh):
     singleBase=(Counter(cleanBases).most_common()[0][0])
     if singleBase == '*':
         singleBase == '-'

--- a/libexec/sisrs/get_pruned_dict.py
+++ b/libexec/sisrs/get_pruned_dict.py
@@ -38,7 +38,7 @@ def getallbases(path,minread,thresh):
     return allbases
 
 def getFinalBase_Pruned(cleanBases,minread,thresh):
-    singleBase=str((Counter(cleanBases).most_common()[0][0]))
+    singleBase=(Counter(cleanBases).most_common()[0][0])
     if singleBase == '*':
         singleBase == '-'
     counts=int((Counter(cleanBases).most_common()[0][1]))

--- a/libexec/sisrs/get_pruned_dict.py
+++ b/libexec/sisrs/get_pruned_dict.py
@@ -33,7 +33,7 @@ def getallbases(path,minread,thresh):
                 cleanBases=getCleanList(ref,bases)  #Get clean bases where * replaced with -
                 assert len(cleanBases) == int(num), 'bases are being counted incorrectly: '+ str(bases) + ' should have '+str(num)+' bases, but it is being converted to '+"".join(cleanBases)
                 finalBase=getFinalBase_Pruned(cleanBases,minread,thresh)
-                if finalBase not 'N':
+                if finalBase != 'N':
                     allbases[loc]=finalBase
     return allbases
 

--- a/libexec/sisrs/get_pruned_dict.py
+++ b/libexec/sisrs/get_pruned_dict.py
@@ -33,6 +33,8 @@ def getallbases(path,minread,thresh):
                 assert len(cleanBases) == int(num), 'bases are being counted incorrectly: '+ str(bases) + ' should have '+str(num)+' bases, but it is being converted to '+"".join(cleanBases)
                 #Extract most common base and its count
                 singleBase=(Counter(cleanBases).most_common()[0][0])
+                if singleBase == '*':
+                    singleBase == '-'
                 counts=int((Counter(cleanBases).most_common()[0][1]))
 
                 if counts < minread:
@@ -44,8 +46,8 @@ def getallbases(path,minread,thresh):
                     finalBase=singleBase
                 else:
                     finalBase='N'
-
-                allbases[loc]=finalBase
+                if finalBase not 'N':
+                    allbases[loc]=finalBase
 
     return allbases
 
@@ -62,10 +64,7 @@ def getCleanList(ref,bases):
     ibase_list = iter(bases)
     for b in ibase_list:
         if b in okbases:
-            if b=='*':
-                new_base_list.append('-')   #Replace deletions with - as placeholder
-            else:
-                new_base_list.append(b)     #Get base
+            new_base_list.append(b)     #Get base
         elif b in indels:                   #skip indels
             i = int(ibase_list.next())
             j = str(ibase_list.next())

--- a/libexec/sisrs/get_pruned_dict.py
+++ b/libexec/sisrs/get_pruned_dict.py
@@ -40,7 +40,7 @@ def getallbases(path,minread,thresh):
 def getFinalBase_Pruned(cleanBases,minread,thresh):
     singleBase=(Counter(cleanBases).most_common()[0][0])
     if singleBase == '*':
-        singleBase == '-'
+        singleBase = '-'
     counts=int((Counter(cleanBases).most_common()[0][1]))
 
     if counts >= minread and counts/float(len(cleanBases)) >= thresh:

--- a/libexec/sisrs/get_pruned_dict.py
+++ b/libexec/sisrs/get_pruned_dict.py
@@ -18,67 +18,70 @@ from collections import Counter
 import glob
 import string
 import re
-from specific_genome import getCleanList
 
 #get combined pileup info
-def getallbases(path):
+def getallbases(path,minread,thresh):
+    assert len(glob.glob1(path,"*.pileups"))==1,'More than one pileup file in'+path
     allbases=dict()
-    for fi in glob.glob(path+'/*pileups'):
-        filein=open(fi,'r')
+    with open (path+'/'+os.path.basename(path)+'.pileups',"r") as filein:
         for line in filein:
             splitline=line.split()
             if len(splitline)>4:
                 node,pos,ref,num,bases,qual=line.split()
-                bases=bases.replace('.',ref) #insert ref base
-                bases=bases.replace(',',ref)
-                bases=bases.replace('*','D')    #using D is easier than *
-                bases=bases.upper() #everything in uppercase
-                bases2 = remove_extra(bases)
-
-                assert len(bases2) == int(num), 'bases are being counted incorrectly: '+\
-                                          bases + ' should have '+str(num)+' bases, but it is being converted to '+"".join(bases2)
-
                 loc=node+'/'+pos
-                if loc in allbases:
-                    allbases[loc].extend(bases2)
+                cleanBases=getCleanList(ref,bases)  #Get clean bases where * replaced with -
+                assert len(cleanBases) == int(num), 'bases are being counted incorrectly: '+ str(bases) + ' should have '+str(num)+' bases, but it is being converted to '+"".join(cleanBases)
+                #Extract most common base and its count
+                singleBase=(Counter(cleanBases).most_common()[0][0])
+                counts=int((Counter(cleanBases).most_common()[0][1]))
+
+                if counts < minread:
+                    finalBase='N'
                 else:
-                    allbases[loc]=bases2
-        filein.close()
+                    finalBase=singleBase
+
+                if counts / float(len(bases)) >= thresh:
+                    finalBase=singleBase
+                else:
+                    finalBase='N'
+
+                allbases[loc]=finalBase
 
     return allbases
 
-#prune by whether there's enough info and species are fixed
-def determine_base(bases,minread,thresh):
-    if(len(bases)< minread): #not enough info
-        base='N'
-    else:
-        counts = Counter(bases).most_common(1)
-        if counts[0][1] / float(len(bases)) >= thresh:
-            base=counts[0][0]
-        else:
-            base='N'
+def getCleanList(ref,bases):
+    bases=bases.replace('.',ref) #insert ref base
+    bases=bases.replace(',',ref)
+    bases=bases.upper() #everything in uppercase
+    bases=list(bases)
 
-    return base
+    okbases=['A','C','G','T','*']
+    indels=['+','-']
 
-def remove_extra(base_str):
-    bases=['A','C','G','T','D']     #D indicates del
     new_base_list=[]
-    ibase_list = iter(re.findall('\-$|\-[0-9]+|\-*[A-Z]*\-*[A-Z]+|\+[0-9]+|\^.',base_str))  #group by bases, indels, read start (need this to get rid of following ascii code), don't worry about $
+    ibase_list = iter(bases)
     for b in ibase_list:
-        if b[0] in string.ascii_uppercase:     #allows for any other characters - filter out later (in case of ZAAA)
-            new_base_list.extend(b)         #get bases
-        elif b[0]=='+' or b[0]=='-':        #skip indels
-            if len(b)>1:
-                if b[1].isdigit():
-                    i = int(b[1:])                  #account for ints >=10
-                    b2=ibase_list.next()
-                    if len(b2) > i:
-                        new_base_list.extend(b2[i:])    #can have real bases after indel bases
-        elif b[0]=='^':                        #skip read qual noted at end of read
-            continue
-    new_base_list = [i for i in new_base_list if i in bases]    #filter unknown bases
+        if b in okbases:
+            if b=='*':
+                new_base_list.append('-')   #Replace deletions with - as placeholder
+            else:
+                new_base_list.append(b)     #Get base
+        elif b in indels:                   #skip indels
+            i = int(ibase_list.next())
+            j = str(ibase_list.next())
+            if str.isdigit(j):
+                skip=int(str(i)+j)
+                while skip>0:
+                    z=ibase_list.next()
+                    skip=skip-1
+            else:
+                while i>1:
+                    z=ibase_list.next()
+                    i = i-1
+        elif b=='^':                        #skip read qual noted at end of read
+            z=ibase_list.next()
 
-    return new_base_list        #list of individual bases
+    return new_base_list
 
 ###############################################
 if __name__ == "__main__":
@@ -86,16 +89,10 @@ if __name__ == "__main__":
     minread=int(sys.argv[2])
     thresh=float(sys.argv[3])
 
-    allbases=getallbases(path)      #dictionary of combined pileups - locus/pos:bases(as list)
+    allbases=getallbases(path,minread,thresh)      #dictionary of combined pileups - locus/pos:bases(as list)
     if len(allbases)==0:
         print 'No data for '+path
         sys.exit(1)      #dictionary of combined pileups - locus/pos:bases(as list)
-
-    for pos in allbases:
-        base = determine_base(allbases[pos],minread,thresh)     #determine if sufficient data and threshold met for calling allele
-        if base is 'D':
-            base='-'
-        allbases[pos] = base
 
     output = open(path+'/pruned_dict.pkl', 'wb')
     cPickle.dump(allbases, output, cPickle.HIGHEST_PROTOCOL)

--- a/libexec/sisrs/get_pruned_dict.py
+++ b/libexec/sisrs/get_pruned_dict.py
@@ -32,18 +32,18 @@ def getallbases(path,minread,thresh):
                 loc=node+'/'+pos
                 cleanBases=getCleanList(ref,bases)  #Get clean bases where * replaced with -
                 assert len(cleanBases) == int(num), 'bases are being counted incorrectly: '+ str(bases) + ' should have '+str(num)+' bases, but it is being converted to '+"".join(cleanBases)
-                finalBase=getFinalBase_Pruned(cleanBases,bases,minread,thresh)
+                finalBase=getFinalBase_Pruned(cleanBases,minread,thresh)
                 if finalBase not 'N':
                     allbases[loc]=finalBase
     return allbases
 
-def getFinalBase_Pruned(cleanBases,bases,minread,thresh):
+def getFinalBase_Pruned(cleanBases,minread,thresh):
     singleBase=(Counter(cleanBases).most_common()[0][0])
     if singleBase == '*':
         singleBase == '-'
     counts=int((Counter(cleanBases).most_common()[0][1]))
 
-    if counts >= minread and counts/float(len(bases)) >= thresh:
+    if counts >= minread and counts/float(len(cleanBases)) >= thresh:
         finalBase=singleBase
     else:
         finalBase='N'

--- a/libexec/sisrs/get_pruned_dict.py
+++ b/libexec/sisrs/get_pruned_dict.py
@@ -32,26 +32,26 @@ def getallbases(path,minread,thresh):
                 loc=node+'/'+pos
                 cleanBases=getCleanList(ref,bases)  #Get clean bases where * replaced with -
                 assert len(cleanBases) == int(num), 'bases are being counted incorrectly: '+ str(bases) + ' should have '+str(num)+' bases, but it is being converted to '+"".join(cleanBases)
-                #Extract most common base and its count
-                singleBase=(Counter(cleanBases).most_common()[0][0])
-                if singleBase == '*':
-                    singleBase == '-'
-                counts=int((Counter(cleanBases).most_common()[0][1]))
-
-                if counts < minread:
-                    finalBase='N'
-                else:
-                    finalBase=singleBase
-
-                if counts / float(len(bases)) >= thresh:
-                    finalBase=singleBase
-                else:
-                    finalBase='N'
+                finalBase=getfinalbase(cleanBases,bases,minread,thresh)
                 if finalBase not 'N':
                     allbases[loc]=finalBase
-
     return allbases
 
+def getfinalbase(cleanBases,bases,minread,thresh):
+    singleBase=(Counter(cleanBases).most_common()[0][0])
+    if singleBase == '*':
+        singleBase == '-'
+    counts=int((Counter(cleanBases).most_common()[0][1]))
+
+    if counts < minread:
+        finalBase='N'
+    else:
+        finalBase=singleBase
+
+    if counts / float(len(bases)) >= thresh:
+        finalBase=singleBase
+    else:
+        finalBase='N'
 ###############################################
 if __name__ == "__main__":
     path=sys.argv[1]

--- a/libexec/sisrs/get_pruned_dict.py
+++ b/libexec/sisrs/get_pruned_dict.py
@@ -18,6 +18,7 @@ from collections import Counter
 import glob
 import string
 import re
+from specific_genome import getCleanList
 
 #get combined pileup info
 def getallbases(path):
@@ -89,7 +90,7 @@ if __name__ == "__main__":
     if len(allbases)==0:
         print 'No data for '+path
         sys.exit(1)      #dictionary of combined pileups - locus/pos:bases(as list)
-        
+
     for pos in allbases:
         base = determine_base(allbases[pos],minread,thresh)     #determine if sufficient data and threshold met for calling allele
         if base is 'D':

--- a/libexec/sisrs/specific_genome.py
+++ b/libexec/sisrs/specific_genome.py
@@ -57,7 +57,6 @@ def getCleanList(ref,bases):
 
 def getFinalBase_Specific(cleanBases):
     finalBase=(Counter(cleanBases).most_common()[0][0])
-    print(finalBase)
     if finalBase == '*':
         finalBase = 'N'
     return finalBase

--- a/libexec/sisrs/specific_genome.py
+++ b/libexec/sisrs/specific_genome.py
@@ -56,7 +56,7 @@ def getCleanList(ref,bases):
     return new_base_list
 
 def getFinalBase_Specific(cleanBases):
-    finalBase=(Counter(cleanBases).most_common()[0][0])
+    finalBase=str((Counter(cleanBases).most_common()[0][0]))
     if finalBase == '*':
         finalBase == 'N'
     return finalBase

--- a/libexec/sisrs/specific_genome.py
+++ b/libexec/sisrs/specific_genome.py
@@ -20,7 +20,7 @@ def getallbases(path):
                 loc=node+'/'+pos
                 cleanBases=getCleanList(ref,bases)
                 assert len(cleanBases) == int(num), 'bases are being counted incorrectly: '+ str(bases) + ' should have '+str(num)+' bases, but it is being converted to '+"".join(cleanBases)
-                finalBase=getFinalBase_Specific(cleanBases,minread,thresh)
+                finalBase=getFinalBase_Specific(cleanBases)
                 allbases[loc]=finalBase
     return allbases
 
@@ -55,7 +55,7 @@ def getCleanList(ref,bases):
 
     return new_base_list
 
-def getFinalBase_Specific(cleanBases,minread,thresh):
+def getFinalBase_Specific(cleanBase):
     finalBase=(Counter(cleanBases).most_common()[0][0])
     if singleBase == '*':
         singleBase == 'N'

--- a/libexec/sisrs/specific_genome.py
+++ b/libexec/sisrs/specific_genome.py
@@ -59,9 +59,7 @@ def getFinalBase_Specific(cleanBases):
     finalBase=(Counter(cleanBases).most_common()[0][0])
     print(finalBase)
     if finalBase == '*':
-        print("Final Base was *")
-        finalBase == 'N'
-        print("Final Base is now "+finalBase)
+        finalBase = 'N'
     return finalBase
 
 ###############################################

--- a/libexec/sisrs/specific_genome.py
+++ b/libexec/sisrs/specific_genome.py
@@ -59,8 +59,9 @@ def getFinalBase_Specific(cleanBases):
     finalBase=(Counter(cleanBases).most_common()[0][0])
     print(finalBase)
     if finalBase == '*':
-        print("yes")
+        print("Final Base was *")
         finalBase == 'N'
+        print("Final Base is now "+finalBase)
     return finalBase
 
 ###############################################

--- a/libexec/sisrs/specific_genome.py
+++ b/libexec/sisrs/specific_genome.py
@@ -59,6 +59,7 @@ def getFinalBase_Specific(cleanBases):
     finalBase=(Counter(cleanBases).most_common()[0][0])
     print(finalBase)
     if finalBase == '*':
+        print("yes")
         finalBase == 'N'
     return finalBase
 

--- a/libexec/sisrs/specific_genome.py
+++ b/libexec/sisrs/specific_genome.py
@@ -57,6 +57,7 @@ def getCleanList(ref,bases):
 
 def getFinalBase_Specific(cleanBases):
     finalBase=(Counter(cleanBases).most_common()[0][0])
+    print(finalBase)
     if finalBase == '*':
         finalBase == 'N'
     return finalBase

--- a/libexec/sisrs/specific_genome.py
+++ b/libexec/sisrs/specific_genome.py
@@ -38,7 +38,7 @@ def getCleanList(ref,bases):
     for b in ibase_list:
         if b in okbases:
             if b=='*':
-                new_base_list.append('D')   #Replace deletions with Ds as placeholder
+                new_base_list.append('N')   #Replace deletions with Ns as placeholder
             else:
                 new_base_list.append(b)     #Get base
         elif b in indels:                   #skip indels

--- a/libexec/sisrs/specific_genome.py
+++ b/libexec/sisrs/specific_genome.py
@@ -20,9 +20,7 @@ def getallbases(path):
                 loc=node+'/'+pos
                 cleanBases=getCleanList(ref,bases)
                 assert len(cleanBases) == int(num), 'bases are being counted incorrectly: '+ str(bases) + ' should have '+str(num)+' bases, but it is being converted to '+"".join(cleanBases)
-                finalBase=(Counter(cleanBases).most_common()[0][0])
-                if finalBase == '*':
-                    finalBase == 'N'
+                finalBase=getFinalBase_Specific(cleanBases,bases,minread,thresh)
                 allbases[loc]=finalBase
     return allbases
 
@@ -57,6 +55,11 @@ def getCleanList(ref,bases):
 
     return new_base_list
 
+def getFinalBase_Specific(cleanBases,bases,minread,thresh):
+    finalBase=(Counter(cleanBases).most_common()[0][0])
+    if singleBase == '*':
+        singleBase == 'N'
+    return finalBase
 
 ###############################################
 if __name__ == "__main__":

--- a/libexec/sisrs/specific_genome.py
+++ b/libexec/sisrs/specific_genome.py
@@ -20,7 +20,7 @@ def getallbases(path):
                 loc=node+'/'+pos
                 cleanBases=getCleanList(ref,bases)
                 assert len(cleanBases) == int(num), 'bases are being counted incorrectly: '+ str(bases) + ' should have '+str(num)+' bases, but it is being converted to '+"".join(cleanBases)
-                finalBase=getFinalBase_Specific(cleanBases,bases,minread,thresh)
+                finalBase=getFinalBase_Specific(cleanBases,minread,thresh)
                 allbases[loc]=finalBase
     return allbases
 
@@ -55,7 +55,7 @@ def getCleanList(ref,bases):
 
     return new_base_list
 
-def getFinalBase_Specific(cleanBases,bases,minread,thresh):
+def getFinalBase_Specific(cleanBases,minread,thresh):
     finalBase=(Counter(cleanBases).most_common()[0][0])
     if singleBase == '*':
         singleBase == 'N'

--- a/libexec/sisrs/specific_genome.py
+++ b/libexec/sisrs/specific_genome.py
@@ -21,6 +21,8 @@ def getallbases(path):
                 cleanBases=getCleanList(ref,bases)
                 assert len(cleanBases) == int(num), 'bases are being counted incorrectly: '+ str(bases) + ' should have '+str(num)+' bases, but it is being converted to '+"".join(cleanBases)
                 finalBase=(Counter(cleanBases).most_common()[0][0])
+                if finalBase == '*':
+                    finalBase == 'N'
                 allbases[loc]=finalBase
     return allbases
 
@@ -37,10 +39,7 @@ def getCleanList(ref,bases):
     ibase_list = iter(bases)
     for b in ibase_list:
         if b in okbases:
-            if b=='*':
-                new_base_list.append('N')   #Replace deletions with Ns as placeholder
-            else:
-                new_base_list.append(b)     #Get base
+            new_base_list.append(b)         #Get base
         elif b in indels:                   #skip indels
             i = int(ibase_list.next())
             j = str(ibase_list.next())

--- a/libexec/sisrs/specific_genome.py
+++ b/libexec/sisrs/specific_genome.py
@@ -57,8 +57,8 @@ def getCleanList(ref,bases):
 
 def getFinalBase_Specific(cleanBases):
     finalBase=(Counter(cleanBases).most_common()[0][0])
-    if singleBase == '*':
-        singleBase == 'N'
+    if finalBase == '*':
+        finalBase == 'N'
     return finalBase
 
 ###############################################

--- a/libexec/sisrs/specific_genome.py
+++ b/libexec/sisrs/specific_genome.py
@@ -56,7 +56,7 @@ def getCleanList(ref,bases):
     return new_base_list
 
 def getFinalBase_Specific(cleanBases):
-    finalBase=str((Counter(cleanBases).most_common()[0][0]))
+    finalBase=(Counter(cleanBases).most_common()[0][0])
     if finalBase == '*':
         finalBase == 'N'
     return finalBase

--- a/libexec/sisrs/specific_genome.py
+++ b/libexec/sisrs/specific_genome.py
@@ -55,7 +55,7 @@ def getCleanList(ref,bases):
 
     return new_base_list
 
-def getFinalBase_Specific(cleanBase):
+def getFinalBase_Specific(cleanBases):
     finalBase=(Counter(cleanBases).most_common()[0][0])
     if singleBase == '*':
         singleBase == 'N'

--- a/libexec/sisrs/test_getCleanList.py
+++ b/libexec/sisrs/test_getCleanList.py
@@ -1,11 +1,11 @@
 #!/usr/bin/env python2
 from specific_genome import getCleanList
 
-def test_answer():
-    assert getCleanList('A','***.......,..^7.^7.^7.^7.^7.^7,') == list('DDDAAAAAAAAAAAAAAAA')
-    assert getCleanList('A','t,.*,.-2TT..,,......,,,.,,,') == list('TAADAAAAAAAAAAAAAAAAAAA')
-    assert getCleanList('G','.,,,,*.$..$.,,,,,,,.') == list('GGGGGDGGGGGGGGGGGG')
+Nef test_answer():
+    assert getCleanList('A','***.......,..^7.^7.^7.^7.^7.^7,') == list('NNNAAAAAAAAAAAAAAAA')
+    assert getCleanList('A','t,.*,.-2TT..,,......,,,.,,,') == list('TAANAAAAAAAAAAAAAAAAAAA')
+    assert getCleanList('G','.,,,,*.$..$.,,,,,,,.') == list('GGGGGNGGGGGGGGGGGG')
     assert getCleanList('T',',+1a,+1a,+1a.+1A.+1A,+1a.+1A') == list('TTTTTTT')
-    assert getCleanList('T','AAaA*A*aA**aaAa') == list('AAAADADAADDAAAA')
+    assert getCleanList('T','AAaA*A*aA**aaAa') == list('AAAANANAANNAAAA')
     assert getCleanList('T','..,....,,,,.,') == list('TTTTTTTTTTTTT')
     assert getCleanList('A',',,....+18AGTTAACCCTAAGGGACC,+18agttaaccctaagggacc,+18agttaaccctaagggacc') == list('AAAAAAAA')

--- a/libexec/sisrs/test_getCleanList.py
+++ b/libexec/sisrs/test_getCleanList.py
@@ -35,7 +35,7 @@ def test_answer():
     assert getFinalBase_Pruned(getCleanList('T','..,....,,,,.,'),3,1)=='T'
 
     assert getFinalBase_Specific(getCleanList('A',',,....+18AGTTAACCCTAAGGGACC,+18agttaaccctaagggacc,+18agttaaccctaagggacc'))=='A'
-    assert getFinalBase_Pruned(getCleanList('A',',,....+18AGTTAACCCTAAGGGACC,+18agttaaccctaagggacc,+18agttaaccctaagggacc'),3,1)=='N'
+    assert getFinalBase_Pruned(getCleanList('A',',,....+18AGTTAACCCTAAGGGACC,+18agttaaccctaagggacc,+18agttaaccctaagggacc'),3,1)=='A'
 
     assert getFinalBase_Specific(getCleanList('T','***.*,*.***,*'))=='N'
     assert getFinalBase_Pruned(getCleanList('T','***.*,*.***,*'),3,1)=='N'

--- a/libexec/sisrs/test_getCleanList.py
+++ b/libexec/sisrs/test_getCleanList.py
@@ -4,6 +4,7 @@ from specific_genome import getFinalBase_Specific
 from get_pruned_dict import getFinalBase_Pruned
 
 def test_answer():
+    #Test getCleanList (Shared function)
     assert getCleanList('A','***.......,..^7.^7.^7.^7.^7.^7,') == list('***AAAAAAAAAAAAAAAA')
     assert getCleanList('A','t,.*,.-2TT..,,......,,,.,,,') == list('TAA*AAAAAAAAAAAAAAAAAAA')
     assert getCleanList('G','.,,,,*.$..$.,,,,,,,.') == list('GGGGG*GGGGGGGGGGGG')
@@ -14,6 +15,7 @@ def test_answer():
     assert getCleanList('T','***.*,*.***,*') == list('***T*T*T***T*')
     assert getCleanList('T','*************') == list('*************')
 
+    #Test getFinalBase for specific_genome and get_pruned_dict (handle deltions differently and minread/thresh)
     assert getFinalBase_Specific(getCleanList('A','***.......,..^7.^7.^7.^7.^7.^7,'))=='A'
     assert getFinalBase_Pruned(getCleanList('A','***.......,..^7.^7.^7.^7.^7.^7,'),3,1)=='N'
 
@@ -22,11 +24,11 @@ def test_answer():
 
     assert getFinalBase_Specific(getCleanList('G','.,,,,*.$..$.,,,,,,,.'))=='G'
     assert getFinalBase_Pruned(getCleanList('G','.,,,,*.$..$.,,,,,,,.'),3,1)=='N'
-    assert getFinalBase_Pruned(getCleanList('G','.,,,,*.$..$.,,,,,,,.'),3,0.93)=='G'
+    assert getFinalBase_Pruned(getCleanList('G','.,,,,*.$..$.,,,,,,,.'),3,0.93)=='G' #Test threshold
 
     assert getFinalBase_Specific(getCleanList('T',',+1a,+1a,+1a.+1A.+1A,+1a.+1A'))=='T'
     assert getFinalBase_Pruned(getCleanList('T',',+1a,+1a,+1a.+1A.+1A,+1a.+1A'),3,1)=='T'
-    assert getFinalBase_Pruned(getCleanList('T',',+1a,+1a,+1a.+1A.+1A,+1a.+1A'),8,1)=='N'
+    assert getFinalBase_Pruned(getCleanList('T',',+1a,+1a,+1a.+1A.+1A,+1a.+1A'),8,1)=='N'   #Test minread
 
     assert getFinalBase_Specific(getCleanList('T','AAaA*A*aA**aaAa'))=='A'
     assert getFinalBase_Pruned(getCleanList('T','AAaA*A*aA**aaAa'),3,1)=='N'
@@ -40,5 +42,6 @@ def test_answer():
     assert getFinalBase_Specific(getCleanList('T','***.*,*.***,*'))=='N'
     assert getFinalBase_Pruned(getCleanList('T','***.*,*.***,*'),3,1)=='N'
 
+    #Test how to handle deletions
     assert getFinalBase_Specific(getCleanList('T','*************'))=='N'
     assert getFinalBase_Pruned(getCleanList('T','*************'),3,1)=='-'

--- a/libexec/sisrs/test_getCleanList.py
+++ b/libexec/sisrs/test_getCleanList.py
@@ -11,3 +11,34 @@ def test_answer():
     assert getCleanList('T','AAaA*A*aA**aaAa') == list('AAAA*A*AA**AAAA')
     assert getCleanList('T','..,....,,,,.,') == list('TTTTTTTTTTTTT')
     assert getCleanList('A',',,....+18AGTTAACCCTAAGGGACC,+18agttaaccctaagggacc,+18agttaaccctaagggacc') == list('AAAAAAAA')
+    assert getCleanList('T','***.*,*.***,*') == list('***T*T*T***T*')
+    assert getCleanList('T','*************') == list('*************')
+
+    assert getFinalBase_Specific(getCleanList('A','***.......,..^7.^7.^7.^7.^7.^7,'))=='A'
+    assert getFinalBase_Pruned(getCleanList('A','***.......,..^7.^7.^7.^7.^7.^7,'),3,1)=='N'
+
+    assert getFinalBase_Specific(getCleanList('A','t,.*,.-2TT..,,......,,,.,,,'))=='A'
+    assert getFinalBase_Pruned(getCleanList('A','t,.*,.-2TT..,,......,,,.,,,'),3,1)=='N'
+
+    assert getFinalBase_Specific(getCleanList('G','.,,,,*.$..$.,,,,,,,.'))=='G'
+    assert getFinalBase_Pruned(getCleanList('G','.,,,,*.$..$.,,,,,,,.'),3,1)=='N'
+    assert getFinalBase_Pruned(getCleanList('G','.,,,,*.$..$.,,,,,,,.'),3,0.93)=='G'
+
+    assert getFinalBase_Specific(getCleanList('T',',+1a,+1a,+1a.+1A.+1A,+1a.+1A'),3,1)=='T'
+    assert getFinalBase_Pruned(getCleanList('T',',+1a,+1a,+1a.+1A.+1A,+1a.+1A'),3,1)=='T'
+    assert getFinalBase_Pruned(getCleanList('T',',+1a,+1a,+1a.+1A.+1A,+1a.+1A'),8,1)=='N'
+
+    assert getFinalBase_Specific(getCleanList('T','AAaA*A*aA**aaAa'))=='A'
+    assert getFinalBase_Pruned(getCleanList('T','AAaA*A*aA**aaAa'),3,1)=='N'
+
+    assert getFinalBase_Specific(getCleanList('T','..,....,,,,.,'))=='T'
+    assert getFinalBase_Pruned(getCleanList('T','..,....,,,,.,'),3,1)=='T'
+
+    assert getFinalBase_Specific(getCleanList('A',',,....+18AGTTAACCCTAAGGGACC,+18agttaaccctaagggacc,+18agttaaccctaagggacc'))=='A'
+    assert getFinalBase_Pruned(getCleanList('A',',,....+18AGTTAACCCTAAGGGACC,+18agttaaccctaagggacc,+18agttaaccctaagggacc'),3,1)=='N'
+
+    assert getFinalBase_Specific(getCleanList('T','***.*,*.***,*'))=='N'
+    assert getFinalBase_Pruned(getCleanList('T','***.*,*.***,*'),3,1)=='N'
+
+    assert getFinalBase_Specific(getCleanList('T','*************'))=='N'
+    assert getFinalBase_Pruned(getCleanList('T','*************'),3,1)=='-'

--- a/libexec/sisrs/test_getCleanList.py
+++ b/libexec/sisrs/test_getCleanList.py
@@ -1,11 +1,11 @@
 #!/usr/bin/env python2
 from specific_genome import getCleanList
 
-Nef test_answer():
-    assert getCleanList('A','***.......,..^7.^7.^7.^7.^7.^7,') == list('NNNAAAAAAAAAAAAAAAA')
-    assert getCleanList('A','t,.*,.-2TT..,,......,,,.,,,') == list('TAANAAAAAAAAAAAAAAAAAAA')
-    assert getCleanList('G','.,,,,*.$..$.,,,,,,,.') == list('GGGGGNGGGGGGGGGGGG')
+def test_answer():
+    assert getCleanList('A','***.......,..^7.^7.^7.^7.^7.^7,') == list('***AAAAAAAAAAAAAAAA')
+    assert getCleanList('A','t,.*,.-2TT..,,......,,,.,,,') == list('TAA*AAAAAAAAAAAAAAAAAAA')
+    assert getCleanList('G','.,,,,*.$..$.,,,,,,,.') == list('GGGGG*GGGGGGGGGGGG')
     assert getCleanList('T',',+1a,+1a,+1a.+1A.+1A,+1a.+1A') == list('TTTTTTT')
-    assert getCleanList('T','AAaA*A*aA**aaAa') == list('AAAANANAANNAAAA')
+    assert getCleanList('T','AAaA*A*aA**aaAa') == list('AAAA*A*AA**AAAA')
     assert getCleanList('T','..,....,,,,.,') == list('TTTTTTTTTTTTT')
     assert getCleanList('A',',,....+18AGTTAACCCTAAGGGACC,+18agttaaccctaagggacc,+18agttaaccctaagggacc') == list('AAAAAAAA')

--- a/libexec/sisrs/test_getCleanList.py
+++ b/libexec/sisrs/test_getCleanList.py
@@ -24,7 +24,7 @@ def test_answer():
     assert getFinalBase_Pruned(getCleanList('G','.,,,,*.$..$.,,,,,,,.'),3,1)=='N'
     assert getFinalBase_Pruned(getCleanList('G','.,,,,*.$..$.,,,,,,,.'),3,0.93)=='G'
 
-    assert getFinalBase_Specific(getCleanList('T',',+1a,+1a,+1a.+1A.+1A,+1a.+1A'),3,1)=='T'
+    assert getFinalBase_Specific(getCleanList('T',',+1a,+1a,+1a.+1A.+1A,+1a.+1A'))=='T'
     assert getFinalBase_Pruned(getCleanList('T',',+1a,+1a,+1a.+1A.+1A,+1a.+1A'),3,1)=='T'
     assert getFinalBase_Pruned(getCleanList('T',',+1a,+1a,+1a.+1A.+1A,+1a.+1A'),8,1)=='N'
 

--- a/libexec/sisrs/test_getCleanList.py
+++ b/libexec/sisrs/test_getCleanList.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python2
 from specific_genome import getCleanList
+from specific_genome import getFinalBase_Specific
+from get_pruned_dict import getFinalBase_Pruned
 
 def test_answer():
     assert getCleanList('A','***.......,..^7.^7.^7.^7.^7.^7,') == list('***AAAAAAAAAAAAAAAA')


### PR DESCRIPTION
specific_genome.py and get_pruned_dict.py are both now working as expected. Single pileups are now streamed in both scripts rather than read in, reducing memory usage fairly drastically. 

The test script has been expanded to include relevant examples, including how to handle deletions, minread/threshold issues, etc. 

In specific_genome.py, deletions (*) are now replaced by Ns for downstream mapping purposes.

In get_pruned_dict.py, deletions are replaced by '-' as this can be used as a character in the subsequent alignment. Only A,T,C,G and - are passed through to the final alignment of sites. Any site called as N (Ns in assembly, Ns due to minread/threshold issues) are not passed through. 

I will now move on to ensure that the get_alignment script is handling the data as expected. 
