### PR TITLE
Parsimony-Informative Sites

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Running SISRS
 
 **outputAlignment**: output alignment file of sisrs sites  
 
-**changeMissing**: given alignment of sites, output a file with only sites missing fewer than a specified number of samples per site  
+**changeMissing**: given alignment of parsimony informative sites (alignment_pi.nex), output a file with only sites missing fewer than a specified number of samples per site  
 
 
  #### Option Flags:

--- a/bin/sisrs
+++ b/bin/sisrs
@@ -423,7 +423,7 @@ outputAlignment(){
 }
 
 changeMissing(){
-    ${DIR}/libexec/sisrs/filter_nexus_for_missing.py ${OUTFOLDER}/alignment.nex ${MISSING}       #alignment w specified number missing
+    ${DIR}/libexec/sisrs/filter_nexus_for_missing.py ${OUTFOLDER}/alignment_pi.nex ${MISSING}       #alignment w specified number missing
     if [[ $? != 0 ]]; then
         echo "filtering for missing failed"
         exit 1
@@ -555,7 +555,7 @@ gfr_trimLoci(){
 }
 
 gfr_selectLoci_MV(){
-    #pick out loci by most variable in alignment.nex
+    #pick out loci by most variable in alignment_pi.nex
     COUNT=0
     POS=1
     if [[ -e "${OUTFOLDER}"/loci/newpartitionsMV.txt ]]; then rm "${OUTFOLDER}"/loci/newpartitionsMV.txt; fi
@@ -578,7 +578,7 @@ gfr_selectLoci_MV(){
 }
 
 gfr_selectLoci_MS(){
-    #pick out loci by most species, then most variable in alignment.nex
+    #pick out loci by most species, then most variable in alignment_pi.nex
     COUNT=0
     POS=1
     if [[ -e "${OUTFOLDER}"/loci/newpartitionsMS.txt ]]; then rm "${OUTFOLDER}"/loci/newpartitionsMS.txt; fi
@@ -645,10 +645,10 @@ if [[ $CMD = "sites" ]] || [[ "${cmds[*]}" =~ $CMD ]]; then
     echo "**** SISRS ****"
     runSISRS
 elif [[ $CMD = "loci" ]]; then
-    # Run SISRS with loci (GFR). First check if alignment.nex and/or ref_genes.fa. If there is no alignment.nex then rerun SISRS to produce file.
+    # Run SISRS with loci (GFR). First check if alignment_pi.nex and/or ref_genes.fa. If there is no alignment_pi.nex then rerun SISRS to produce file.
     if [[ -f "${FOLDERLISTA[0]}"/ref_genes.fa ]]; then
         echo "** Running SISRS loci **"
-    elif [[ -f "${OUTFOLDER}"/alignment.nex ]]; then
+    elif [[ -f "${OUTFOLDER}"/alignment_pi.nex ]]; then
         echo "** Missing reference, getting from SISRS sites alignment **"
 	copyRefContigs  # Get ref_genes.fa from previous sisrs run
     elif [[ -f "${OUTFOLDER}"/ref_genes.fa ]]; then

--- a/bin/sisrs
+++ b/bin/sisrs
@@ -465,7 +465,7 @@ runSISRS(){
       ${cmds[$i]}
     fi
 
-    #run as raxml -s "${OUTFOLDER}"/alignment_mX.phylip-relaxed -n <out> -m ASC_GTRGAMMA [--asc-corr=lewis] -T $1 -f a -p $RANDOM -N 100 -x $RANDOM
+    #run as raxml -s "${OUTFOLDER}"/alignment_pi_mX.phylip-relaxed -n <out> -m ASC_GTRGAMMA [--asc-corr=lewis] -T $1 -f a -p $RANDOM -N 100 -x $RANDOM
 }
 
 ####################LOCI#######################

--- a/bin/sisrs
+++ b/bin/sisrs
@@ -432,8 +432,11 @@ changeMissing(){
     tr " " "\n" < ${OUTFOLDER}/locs_m${MISSING}.txt | grep -oe "SISRS_[^/]*" - | uniq -c | sort -k1 -nr | awk '{print $2}' > "${OUTFOLDER}/locs_m${MISSING}_Clean.txt"
 
     #Parallel processing of alignment.nex for comparison
-    mkdir ${OUTFOLDER}/alignmentDataWithSingletons
-    mv ${OUTFOLDER}/alignment.nex ${OUTFOLDER}/alignmentDataWithSingletons
+    if [[ ! -d "${OUTFOLDER}}/alignmentDataWithSingletons" ]]; then
+        mkdir ${OUTFOLDER}/alignmentDataWithSingletons
+        mv ${OUTFOLDER}/alignment.nex ${OUTFOLDER}/alignmentDataWithSingletons
+    fi
+
     ${DIR}/libexec/sisrs/filter_nexus_for_missing.py ${OUTFOLDER}/alignmentDataWithSingletons/alignment.nex ${MISSING}       #alignment w specified number missing from alignment.nex
     if [[ $? != 0 ]]; then
         echo "filtering for missing failed"

--- a/bin/sisrs
+++ b/bin/sisrs
@@ -423,13 +423,24 @@ outputAlignment(){
 }
 
 changeMissing(){
-    ${DIR}/libexec/sisrs/filter_nexus_for_missing.py ${OUTFOLDER}/alignment_pi.nex ${MISSING}       #alignment w specified number missing
+    ${DIR}/libexec/sisrs/filter_nexus_for_missing.py ${OUTFOLDER}/alignment_pi.nex ${MISSING}       #alignment w specified number missing from alignment_pi.nex
     if [[ $? != 0 ]]; then
         echo "filtering for missing failed"
         exit 1
     fi
     #Clean locs_m*.txt file
     tr " " "\n" < ${OUTFOLDER}/locs_m${MISSING}.txt | grep -oe "SISRS_[^/]*" - | uniq -c | sort -k1 -nr | awk '{print $2}' > "${OUTFOLDER}/locs_m${MISSING}_Clean.txt"
+
+    #Parallel processing of alignment.nex for comparison
+    mkdir ${OUTFOLDER}/alignmentDataWithSingletons
+    mv ${OUTFOLDER}/alignment.nex ${OUTFOLDER}/alignmentDataWithSingletons
+    ${DIR}/libexec/sisrs/filter_nexus_for_missing.py ${OUTFOLDER}/alignmentDataWithSingletons/alignment.nex ${MISSING}       #alignment w specified number missing from alignment.nex
+    if [[ $? != 0 ]]; then
+        echo "filtering for missing failed"
+        exit 1
+    fi
+    #Clean locs_m*.txt file
+    tr " " "\n" < ${OUTFOLDER}/alignmentDataWithSingletons/locs_m${MISSING}.txt | grep -oe "SISRS_[^/]*" - | uniq -c | sort -k1 -nr | awk '{print $2}' > "${OUTFOLDER}/alignmentDataWithSingletons/locs_m${MISSING}_Clean.txt"
 }
 
 runSISRS(){


### PR DESCRIPTION
SISRS identifies sites which are fixed within and variable among taxa. It also notes whether the variable sites represent singletons or parsimony informative sites, outputting all variable sites (including singletons) to alignment.nex and only PI sites (no singletons) to alignment_pi.nex. 

Downstream from that step, however, changeMissing and loci were using the alignment.nex information, which contains many variable sites which are singletons (50% of sites in my primate analysis, 11M/22M sites). In that vein, I adjusted SISRS to output data from alignment_pi.nex for downstream analysis (changeMissing + loci), while outputting parallel data from alignment.nex into a new sub-directory. Maintaining the alignment.nex file data is critical, as singleton sites do carry information about rates of evolution.

As the distinction between these datasets is explored more fully, we can think about how this data can be used, or whether it's even worthwhile to make such a distinction. By separating out the data as I have done here, it will allow us to test whether including singletons has any impact on subsequent tree-building. 