### PR TITLE
PI Sites

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Running SISRS
 
 **outputAlignment**: output alignment file of sisrs sites  
 
-**changeMissing**: given alignment of sites, output a file with only sites missing fewer than a specified number of samples per site  
+**changeMissing**: given alignment of parsimony informative sites (alignment_pi.nex), output a file with only sites missing fewer than a specified number of samples per site  
 
 
  #### Option Flags:

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Running SISRS
 
 **outputAlignment**: output alignment file of sisrs sites  
 
-**changeMissing**: given alignment of parsimony informative sites (alignment_pi.nex), output a file with only sites missing fewer than a specified number of samples per site  
+**changeMissing**: given alignment of sites (alignment.nex), output a file with only sites missing fewer than a specified number of samples per site  
 
 
  #### Option Flags:

--- a/bin/sisrs
+++ b/bin/sisrs
@@ -423,7 +423,7 @@ outputAlignment(){
 }
 
 changeMissing(){
-    ${DIR}/libexec/sisrs/filter_nexus_for_missing.py ${OUTFOLDER}/alignment.nex ${MISSING}       #alignment w specified number missing
+    ${DIR}/libexec/sisrs/filter_nexus_for_missing.py ${OUTFOLDER}/alignment_pi.nex ${MISSING}       #alignment w specified number missing
     if [[ $? != 0 ]]; then
         echo "filtering for missing failed"
         exit 1
@@ -555,7 +555,7 @@ gfr_trimLoci(){
 }
 
 gfr_selectLoci_MV(){
-    #pick out loci by most variable in alignment.nex
+    #pick out loci by most variable in alignment_pi.nex
     COUNT=0
     POS=1
     if [[ -e "${OUTFOLDER}"/loci/newpartitionsMV.txt ]]; then rm "${OUTFOLDER}"/loci/newpartitionsMV.txt; fi
@@ -578,7 +578,7 @@ gfr_selectLoci_MV(){
 }
 
 gfr_selectLoci_MS(){
-    #pick out loci by most species, then most variable in alignment.nex
+    #pick out loci by most species, then most variable in alignment_pi.nex
     COUNT=0
     POS=1
     if [[ -e "${OUTFOLDER}"/loci/newpartitionsMS.txt ]]; then rm "${OUTFOLDER}"/loci/newpartitionsMS.txt; fi
@@ -645,10 +645,10 @@ if [[ $CMD = "sites" ]] || [[ "${cmds[*]}" =~ $CMD ]]; then
     echo "**** SISRS ****"
     runSISRS
 elif [[ $CMD = "loci" ]]; then
-    # Run SISRS with loci (GFR). First check if alignment.nex and/or ref_genes.fa. If there is no alignment.nex then rerun SISRS to produce file.
+    # Run SISRS with loci (GFR). First check if alignment_pi.nex and/or ref_genes.fa. If there is no alignment_pi.nex then rerun SISRS to produce file.
     if [[ -f "${FOLDERLISTA[0]}"/ref_genes.fa ]]; then
         echo "** Running SISRS loci **"
-    elif [[ -f "${OUTFOLDER}"/alignment.nex ]]; then
+    elif [[ -f "${OUTFOLDER}"/alignment_pi.nex ]]; then
         echo "** Missing reference, getting from SISRS sites alignment **"
 	copyRefContigs  # Get ref_genes.fa from previous sisrs run
     elif [[ -f "${OUTFOLDER}"/ref_genes.fa ]]; then

--- a/bin/sisrs
+++ b/bin/sisrs
@@ -465,7 +465,7 @@ runSISRS(){
       ${cmds[$i]}
     fi
 
-    #run as raxml -s "${OUTFOLDER}"/alignment_mX.phylip-relaxed -n <out> -m ASC_GTRGAMMA [--asc-corr=lewis] -T $1 -f a -p $RANDOM -N 100 -x $RANDOM
+    #run as raxml -s "${OUTFOLDER}"/alignment_pi_mX.phylip-relaxed -n <out> -m ASC_GTRGAMMA [--asc-corr=lewis] -T $1 -f a -p $RANDOM -N 100 -x $RANDOM
 }
 
 ####################LOCI#######################

--- a/bin/sisrs
+++ b/bin/sisrs
@@ -432,8 +432,11 @@ changeMissing(){
     tr " " "\n" < ${OUTFOLDER}/locs_m${MISSING}.txt | grep -oe "SISRS_[^/]*" - | uniq -c | sort -k1 -nr | awk '{print $2}' > "${OUTFOLDER}/locs_m${MISSING}_Clean.txt"
 
     #Parallel processing of alignment.nex for comparison
-    mkdir ${OUTFOLDER}/alignmentDataWithSingletons
-    mv ${OUTFOLDER}/alignment.nex ${OUTFOLDER}/alignmentDataWithSingletons
+    if [[ ! -d "${OUTFOLDER}}/alignmentDataWithSingletons" ]]; then
+        mkdir ${OUTFOLDER}/alignmentDataWithSingletons
+        mv ${OUTFOLDER}/alignment.nex ${OUTFOLDER}/alignmentDataWithSingletons
+    fi
+
     ${DIR}/libexec/sisrs/filter_nexus_for_missing.py ${OUTFOLDER}/alignmentDataWithSingletons/alignment.nex ${MISSING}       #alignment w specified number missing from alignment.nex
     if [[ $? != 0 ]]; then
         echo "filtering for missing failed"

--- a/bin/sisrs
+++ b/bin/sisrs
@@ -429,7 +429,7 @@ changeMissing(){
         exit 1
     fi
     #Clean locs_m*.txt file
-    tr " " "\n" < ${OUTFOLDER}/locs_m${MISSING}.txt | grep -oe "SISRS_[^/]*" - | uniq -c | sort -k1 -nr | awk '{print $2}' > "${OUTFOLDER}/locs_m${MISSING}_Clean.txt"
+    grep -oe "SISRS_[^/]*" ${OUTFOLDER}/locs_m${MISSING}.txt | uniq -c | sort -k1 -nr | awk '{print $2}' > "${OUTFOLDER}/locs_m${MISSING}_Clean.txt"
 
     #Parallel processing of alignment_pi.nex for comparison
     if [[ ! -d "${OUTFOLDER}}/alignmentDataWithoutSingletons" ]]; then
@@ -443,7 +443,7 @@ changeMissing(){
         exit 1
     fi
     #Clean locs_m*.txt file
-    tr " " "\n" < ${OUTFOLDER}/alignmentDataWithoutSingletons/locs_m${MISSING}.txt | grep -oe "SISRS_[^/]*" - | uniq -c | sort -k1 -nr | awk '{print $2}' > "${OUTFOLDER}/alignmentDataWithoutSingletons/locs_m${MISSING}_Clean.txt"
+    grep -oe "SISRS_[^/]*" ${OUTFOLDER}/alignmentDataWithoutSingletons/locs_m${MISSING}.txt | uniq -c | sort -k1 -nr | awk '{print $2}' > "${OUTFOLDER}/alignmentDataWithoutSingletons/locs_m${MISSING}_Clean.txt"
 }
 
 runSISRS(){

--- a/bin/sisrs
+++ b/bin/sisrs
@@ -423,7 +423,7 @@ outputAlignment(){
 }
 
 changeMissing(){
-    ${DIR}/libexec/sisrs/filter_nexus_for_missing.py ${OUTFOLDER}/alignment_pi.nex ${MISSING}       #alignment w specified number missing from alignment_pi.nex
+    ${DIR}/libexec/sisrs/filter_nexus_for_missing.py ${OUTFOLDER}/alignment.nex ${MISSING}       #alignment w specified number missing from alignment_pi.nex
     if [[ $? != 0 ]]; then
         echo "filtering for missing failed"
         exit 1
@@ -431,19 +431,19 @@ changeMissing(){
     #Clean locs_m*.txt file
     tr " " "\n" < ${OUTFOLDER}/locs_m${MISSING}.txt | grep -oe "SISRS_[^/]*" - | uniq -c | sort -k1 -nr | awk '{print $2}' > "${OUTFOLDER}/locs_m${MISSING}_Clean.txt"
 
-    #Parallel processing of alignment.nex for comparison
-    if [[ ! -d "${OUTFOLDER}}/alignmentDataWithSingletons" ]]; then
-        mkdir ${OUTFOLDER}/alignmentDataWithSingletons
-        mv ${OUTFOLDER}/alignment.nex ${OUTFOLDER}/alignmentDataWithSingletons
+    #Parallel processing of alignment_pi.nex for comparison
+    if [[ ! -d "${OUTFOLDER}}/alignmentDataWithoutSingletons" ]]; then
+        mkdir ${OUTFOLDER}/alignmentDataWithoutSingletons
+        mv ${OUTFOLDER}/alignment_pi.nex ${OUTFOLDER}/alignmentDataWithoutSingletons
     fi
 
-    ${DIR}/libexec/sisrs/filter_nexus_for_missing.py ${OUTFOLDER}/alignmentDataWithSingletons/alignment.nex ${MISSING}       #alignment w specified number missing from alignment.nex
+    ${DIR}/libexec/sisrs/filter_nexus_for_missing.py ${OUTFOLDER}/alignmentDataWithoutSingletons/alignment_pi.nex ${MISSING}       #alignment w specified number missing from alignment.nex
     if [[ $? != 0 ]]; then
         echo "filtering for missing failed"
         exit 1
     fi
     #Clean locs_m*.txt file
-    tr " " "\n" < ${OUTFOLDER}/alignmentDataWithSingletons/locs_m${MISSING}.txt | grep -oe "SISRS_[^/]*" - | uniq -c | sort -k1 -nr | awk '{print $2}' > "${OUTFOLDER}/alignmentDataWithSingletons/locs_m${MISSING}_Clean.txt"
+    tr " " "\n" < ${OUTFOLDER}/alignmentDataWithoutSingletons/locs_m${MISSING}.txt | grep -oe "SISRS_[^/]*" - | uniq -c | sort -k1 -nr | awk '{print $2}' > "${OUTFOLDER}/alignmentDataWithoutSingletons/locs_m${MISSING}_Clean.txt"
 }
 
 runSISRS(){
@@ -465,7 +465,7 @@ runSISRS(){
       ${cmds[$i]}
     fi
 
-    #run as raxml -s "${OUTFOLDER}"/alignment_pi_mX.phylip-relaxed -n <out> -m ASC_GTRGAMMA [--asc-corr=lewis] -T $1 -f a -p $RANDOM -N 100 -x $RANDOM
+    #run as raxml -s "${OUTFOLDER}"/alignment_mX.phylip-relaxed -n <out> -m ASC_GTRGAMMA [--asc-corr=lewis] -T $1 -f a -p $RANDOM -N 100 -x $RANDOM
 }
 
 ####################LOCI#######################

--- a/bin/sisrs
+++ b/bin/sisrs
@@ -423,7 +423,7 @@ outputAlignment(){
 }
 
 changeMissing(){
-    ${DIR}/libexec/sisrs/filter_nexus_for_missing.py ${OUTFOLDER}/alignment.nex ${MISSING}       #alignment w specified number missing from alignment_pi.nex
+    ${DIR}/libexec/sisrs/filter_nexus_for_missing.py ${OUTFOLDER}/alignment.nex ${MISSING}       #alignment w specified number missing from alignment.nex
     if [[ $? != 0 ]]; then
         echo "filtering for missing failed"
         exit 1
@@ -569,7 +569,7 @@ gfr_trimLoci(){
 }
 
 gfr_selectLoci_MV(){
-    #pick out loci by most variable in alignment_pi.nex
+    #pick out loci by most variable in alignment.nex
     COUNT=0
     POS=1
     if [[ -e "${OUTFOLDER}"/loci/newpartitionsMV.txt ]]; then rm "${OUTFOLDER}"/loci/newpartitionsMV.txt; fi
@@ -592,7 +592,7 @@ gfr_selectLoci_MV(){
 }
 
 gfr_selectLoci_MS(){
-    #pick out loci by most species, then most variable in alignment_pi.nex
+    #pick out loci by most species, then most variable in alignment.nex
     COUNT=0
     POS=1
     if [[ -e "${OUTFOLDER}"/loci/newpartitionsMS.txt ]]; then rm "${OUTFOLDER}"/loci/newpartitionsMS.txt; fi
@@ -659,10 +659,10 @@ if [[ $CMD = "sites" ]] || [[ "${cmds[*]}" =~ $CMD ]]; then
     echo "**** SISRS ****"
     runSISRS
 elif [[ $CMD = "loci" ]]; then
-    # Run SISRS with loci (GFR). First check if alignment_pi.nex and/or ref_genes.fa. If there is no alignment_pi.nex then rerun SISRS to produce file.
+    # Run SISRS with loci (GFR). First check if alignment.nex and/or ref_genes.fa. If there is no alignment.nex then rerun SISRS to produce file.
     if [[ -f "${FOLDERLISTA[0]}"/ref_genes.fa ]]; then
         echo "** Running SISRS loci **"
-    elif [[ -f "${OUTFOLDER}"/alignment_pi.nex ]]; then
+    elif [[ -f "${OUTFOLDER}"/alignment.nex ]]; then
         echo "** Missing reference, getting from SISRS sites alignment **"
 	copyRefContigs  # Get ref_genes.fa from previous sisrs run
     elif [[ -f "${OUTFOLDER}"/ref_genes.fa ]]; then

--- a/bin/sisrs
+++ b/bin/sisrs
@@ -423,13 +423,24 @@ outputAlignment(){
 }
 
 changeMissing(){
-    ${DIR}/libexec/sisrs/filter_nexus_for_missing.py ${OUTFOLDER}/alignment_pi.nex ${MISSING}       #alignment w specified number missing
+    ${DIR}/libexec/sisrs/filter_nexus_for_missing.py ${OUTFOLDER}/alignment_pi.nex ${MISSING}       #alignment w specified number missing from alignment_pi.nex
     if [[ $? != 0 ]]; then
         echo "filtering for missing failed"
         exit 1
     fi
     #Clean locs_m*.txt file
     tr " " "\n" < ${OUTFOLDER}/locs_m${MISSING}.txt | grep -oe "SISRS_[^/]*" - | uniq -c | sort -k1 -nr | awk '{print $2}' > "${OUTFOLDER}/locs_m${MISSING}_Clean.txt"
+
+    #Parallel processing of alignment.nex for comparison
+    mkdir ${OUTFOLDER}/alignmentDataWithSingletons
+    mv ${OUTFOLDER}/alignment.nex ${OUTFOLDER}/alignmentDataWithSingletons
+    ${DIR}/libexec/sisrs/filter_nexus_for_missing.py ${OUTFOLDER}/alignmentDataWithSingletons/alignment.nex ${MISSING}       #alignment w specified number missing from alignment.nex
+    if [[ $? != 0 ]]; then
+        echo "filtering for missing failed"
+        exit 1
+    fi
+    #Clean locs_m*.txt file
+    tr " " "\n" < ${OUTFOLDER}/alignmentDataWithSingletons/locs_m${MISSING}.txt | grep -oe "SISRS_[^/]*" - | uniq -c | sort -k1 -nr | awk '{print $2}' > "${OUTFOLDER}/alignmentDataWithSingletons/locs_m${MISSING}_Clean.txt"
 }
 
 runSISRS(){

--- a/libexec/sisrs/filter_nexus_for_missing.py
+++ b/libexec/sisrs/filter_nexus_for_missing.py
@@ -5,7 +5,7 @@
     arguments:
     data  -- extension should be nex/phy/fa
     missing -- the number of species in the alignment allowed to have missing data
-    
+
     output:
     phylip formatted file ending with _mX.phylip-relaxed where X is the number missing
     """
@@ -20,7 +20,7 @@ from Bio.Align import MultipleSeqAlignment, AlignInfo
 from Bio import AlignIO, SeqIO
 
 ######################
-bases = ['A', 'C', 'G', 'T', 'a', 'c', 'g', 't']
+bases = ['A', 'C', 'G', 'T', 'a', 'c', 'g', 't','-']
 formats = {'nex':'nexus', 'phy':'phylip-relaxed', 'fa':'fasta'}
 fformat = formats[sys.argv[1].split('.')[-1]]
 missing = int(sys.argv[2])
@@ -49,5 +49,5 @@ for k,v in newdata.iteritems():
 
 SeqIO.write(datalist, path.dirname(sys.argv[1])+'/'+path.basename(sys.argv[1]).split('.')[0]+'_m'+sys.argv[2]+'.phylip-relaxed', "phylip-relaxed")
 locfile = open(path.dirname(sys.argv[1])+'/locs_m'+sys.argv[2]+'.txt', 'w')
-locfile.write(" ".join(newlocs))
+locfile.write("\n".join(newlocs))
 locfile.close()


### PR DESCRIPTION
SISRS identifies sites which are fixed within and variable among taxa. It also notes whether the variable sites represent singletons or parsimony informative sites, outputting all among-taxa variable sites (including singletons) to alignment.nex and only PI sites (no singletons) to alignment_pi.nex. 

Downstream from that step, however, changeMissing and loci were using the alignment.nex information, which contains many variable sites which are singletons (50% of sites in my primate analysis, 11M/22M sites). The effect of including such sites downstream is not immediately clear, and so I wanted to run some tests.

In order to test the effects of singleton sites on different downstream analyses, I added a bit of code to output data from alignment_pi.nex just as it does in alignment.nex. The alignment_pi.nex data is output to a separate sub-directory and the base code for SISRS still uses the alignment.nex data to run changeMissing and loci (no changes to how SISRS was running before). 

I will use these data to test whether contigs containing different ratios of singletons/PI sites produce more or less accurate trees. 

Note: Originally I had made changes such that SISRS used alignment_pi.nex as default, but I went back and reverted it, instead maintaining native SISRS behavior while merely collected PI data on the side. 