### PR TITLE
Fixed a bracket/quote issue

### DIFF
--- a/bin/sisrs
+++ b/bin/sisrs
@@ -432,7 +432,7 @@ changeMissing(){
     grep -oe "SISRS_[^/]*" ${OUTFOLDER}/locs_m${MISSING}.txt | uniq -c | sort -k1 -nr | awk '{print $2}' > "${OUTFOLDER}/locs_m${MISSING}_Clean.txt"
 
     #Parallel processing of alignment_pi.nex for comparison
-    if [[ ! -d ${OUTFOLDER}}/alignmentDataWithoutSingletons ]]; then
+    if [[ ! -d ${OUTFOLDER}/alignmentDataWithoutSingletons ]]; then
         mkdir ${OUTFOLDER}/alignmentDataWithoutSingletons
         mv ${OUTFOLDER}/alignment_pi.nex ${OUTFOLDER}/alignmentDataWithoutSingletons
     fi

--- a/bin/sisrs
+++ b/bin/sisrs
@@ -432,7 +432,7 @@ changeMissing(){
     grep -oe "SISRS_[^/]*" ${OUTFOLDER}/locs_m${MISSING}.txt | uniq -c | sort -k1 -nr | awk '{print $2}' > "${OUTFOLDER}/locs_m${MISSING}_Clean.txt"
 
     #Parallel processing of alignment_pi.nex for comparison
-    if [[ ! -d "${OUTFOLDER}}/alignmentDataWithoutSingletons" ]]; then
+    if [[ ! -d ${OUTFOLDER}}/alignmentDataWithoutSingletons ]]; then
         mkdir ${OUTFOLDER}/alignmentDataWithoutSingletons
         mv ${OUTFOLDER}/alignment_pi.nex ${OUTFOLDER}/alignmentDataWithoutSingletons
     fi


### PR DESCRIPTION
changeMissing now moves alignment_pi.nex to a new sub-directory (if needed) and extracts data about PI sites given ${MISSING} allowed. 

This pull just fixed a quote/bracket issue which disrupted the directory check step