### PR TITLE
Added biallelic option

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,10 +100,11 @@ Running SISRS
  * -o : the length of the final loci dataset for dating  
  * -l : the number of alleles  
  * -a : assembler [velvet, minia, abyss, or premade; *Default: velvet*]
-      - If using a premade composite genome, it must be in a folder named 'premadeoutput' in the same directory as the folders of read data, and must be called 'contigs.fa' 
- * -s : Include singletons in alignment when running 'loci' [1,0]
-      - 1 [Default]: Include singletons when considering variable loci for 'loci' command
-      - 0: Remove singleton mutations (sites where only one taxon has a substitution at a position) from alignment file prior to running 'loci'
+      - If using a premade composite genome, it must be in a folder named 'premadeoutput' in the same directory as the folders of read data, and must be called 'contigs.fa'
+ * -s : Sites to analyze when running 'loci' [0,1,2]
+      - 0 [Default], all variable sites, including singletons
+      - 1, variable sites excluding singletons
+      - 2, only biallelic variable sites
  * -c : continuous command mode for calling subcommands [1,0]  
       - 1 [Default]: calling a subcommand runs that subcommand **and all subsequent steps in the pipeline**
       - 0: calling a subcommand runs **only** that subcommand

--- a/bin/sisrs
+++ b/bin/sisrs
@@ -82,11 +82,11 @@ Option Flags:
       'premadeoutput' in the same directory as the folders of read data,
       and must be called 'contigs.fa'
  -s : Sites to analyze when running 'loci' [0,1,2]
-      Default=0, all variable sites, including singletons
+      0 [Default], all variable sites, including singletons
       1, variable sites excluding singletons
       2, only biallelic variable sites
  -c : continous command mode for calling subcommands [1,0]
-      Default=1, calling a subcommand runs that subcommand and all subsequent
+      1 [Default], calling a subcommand runs that subcommand and all subsequent
       steps in the pipeline
       0, calling a subcommand runs only that subcommand
 

--- a/bin/sisrs
+++ b/bin/sisrs
@@ -492,13 +492,13 @@ runSISRS(){
 ####################LOCI#######################
 
 copyRefContigs(){
-  if [[ ${SINGLETON} == 0 ]]; then
+  if [[ ${SITES} == 0 ]]; then
     LOCDIR=${OUTFOLDER}
     echo "=== Using data from alignment.nex (Including Singletons) ==="
-  elif  [[ ${SINGLETON} == 1 ]]; then
+  elif  [[ ${SITES} == 1 ]]; then
     LOCDIR=${OUTFOLDER}/alignmentDataWithoutSingletons
     echo "=== Using data from alignment_pi.nex (Excluding Singletons) ==="
-  elif  [[ ${SINGLETON} == 2 ]]; then
+  elif  [[ ${SITES} == 2 ]]; then
     LOCDIR=${OUTFOLDER}/alignmentDataWithOnlyBiallelic
     echo "=== Using data from alignment_bi.nex (Only Biallelic Sites) ==="
   fi

--- a/bin/sisrs
+++ b/bin/sisrs
@@ -599,7 +599,7 @@ gfr_trimLoci(){
     mkdir "${OUTFOLDER}"/loci/rawAlignmentsWithEmptyTaxa  #Directory to store raw loci alignments prior to removing empty taxa
     mkdir "${OUTFOLDER}"/loci/lostLoci #Directory to dump loci where empty taxa > ${MISSING}
 
-    find "${OUTFOLDER}"/loci/ -type f -maxdepth 1 -name "SISRS*_align.fa" | parallel -j "${PROCESSORS}" "${DIR}/libexec/gfr/remove_empty_seqs_from_alignments.py {} ${MISSING}"
+    find "${OUTFOLDER}"/loci/ -maxdepth 1 -type f -name "SISRS*_align.fa" | parallel -j "${PROCESSORS}" "${DIR}/libexec/gfr/remove_empty_seqs_from_alignments.py {} ${MISSING}"
     find "${OUTFOLDER}"/loci/ -maxdepth 1 -type f -name "SISRS*align.fa" | parallel -j "${PROCESSORS}" "${DIR}/libexec/gfr/convert_formats.py {} fasta phylip-relaxed"     #convert to phy
 
     mv "${OUTFOLDER}"/loci.txt "${OUTFOLDER}"/loci_original.txt #Create backup of original loci.txt file

--- a/bin/sisrs
+++ b/bin/sisrs
@@ -81,12 +81,14 @@ Option Flags:
       -If using a premade composite genome, it must be in a folder named
       'premadeoutput' in the same directory as the folders of read data,
       and must be called 'contigs.fa'
- -s : Include singleton sites in alingment for 'loci' [1,0]
-      Default=1, singleton substitutions are considered; 0, singlton sites
-      are removed from the alignment prior to running 'loci'
+ -s : Sites to analyze when running 'loci' [0,1,2]
+      Default=0, all variable sites, including singletons
+      1, variable sites excluding singletons
+      2, only biallelic variable sites
  -c : continous command mode for calling subcommands [1,0]
       Default=1, calling a subcommand runs that subcommand and all subsequent
-      steps in the pipeline; 0, calling a subcommand runs only that subcommand
+      steps in the pipeline
+      0, calling a subcommand runs only that subcommand
 
 Note Regarding Subcommands: If calling a subcommand of sisrs, the folder
                             specified by -f (or pwd) must contain a previous
@@ -112,7 +114,7 @@ ALLELES=1
 DEBUG=0
 ASSEMBLER=velvet
 OUTLENGTH=500000
-SINGLETON=1
+SITES=0
 CMD=$1
 SUBCOMMAND=1
 
@@ -140,7 +142,7 @@ do
 	t) THRESHOLD=${OPTARG};;
   o) OUTLENGTH=${OPTARG};;
   l) ALLELES=${OPTARG};;
-  s) SINGLETON=${OPTARG};;
+  s) SITES=${OPTARG};;
   c) SUBCOMMAND=${OPTARG};;
 	d) DEBUG=1;;
 	h) help; exit;;
@@ -449,6 +451,20 @@ changeMissing(){
     fi
     #Clean locs_m*.txt file
     grep -oe "SISRS_[^/]*" ${OUTFOLDER}/alignmentDataWithoutSingletons/locs_m${MISSING}.txt | uniq -c | sort -k1 -nr | awk '{print $2}' > "${OUTFOLDER}/alignmentDataWithoutSingletons/locs_m${MISSING}_Clean.txt"
+
+    #Parallel processing of alignment_bi.nex for comparison
+    if [[ ! -d ${OUTFOLDER}/alignmentDataWithOnlyBiallelic ]]; then
+        mkdir ${OUTFOLDER}/alignmentDataWithOnlyBiallelic
+        mv ${OUTFOLDER}/alignment_bi.nex ${OUTFOLDER}/alignmentDataWithOnlyBiallelic
+    fi
+
+    ${DIR}/libexec/sisrs/filter_nexus_for_missing.py ${OUTFOLDER}/alignmentDataWithOnlyBiallelic/alignment_bi.nex ${MISSING}       #alignment w specified number missing from alignment.nex
+    if [[ $? != 0 ]]; then
+        echo "filtering for missing failed"
+        exit 1
+    fi
+    #Clean locs_m*.txt file
+    grep -oe "SISRS_[^/]*" ${OUTFOLDER}/alignmentDataWithOnlyBiallelic/locs_m${MISSING}.txt | uniq -c | sort -k1 -nr | awk '{print $2}' > "${OUTFOLDER}/alignmentDataWithOnlyBiallelic/locs_m${MISSING}_Clean.txt"
 }
 
 runSISRS(){
@@ -476,12 +492,15 @@ runSISRS(){
 ####################LOCI#######################
 
 copyRefContigs(){
-  if [[ ${SINGLETON} == 1 ]]; then
+  if [[ ${SINGLETON} == 0 ]]; then
     LOCDIR=${OUTFOLDER}
     echo "=== Using data from alignment.nex (Including Singletons) ==="
-  else
+  elif  [[ ${SINGLETON} == 1 ]]; then
     LOCDIR=${OUTFOLDER}/alignmentDataWithoutSingletons
     echo "=== Using data from alignment_pi.nex (Excluding Singletons) ==="
+  elif  [[ ${SINGLETON} == 2 ]]; then
+    LOCDIR=${OUTFOLDER}/alignmentDataWithOnlyBiallelic
+    echo "=== Using data from alignment_bi.nex (Only Biallelic Sites) ==="
   fi
 
   if [[ -e "${LOCDIR}/locs_m${MISSING}_Clean.txt" ]];then
@@ -587,7 +606,7 @@ gfr_trimLoci(){
 
     find "${OUTFOLDER}"/loci/ -maxdepth 1 -type f -name "SISRS*.phylip-relaxed" -printf "%f\n" | sed 's/\.[^.]*$//' | sed 's/_align//' > "${OUTFOLDER}"/loci.txt #Create new loci.txt file to only reference loci where <= missing taxa were removed
     find "${OUTFOLDER}"/loci/lostLoci/ -maxdepth 1 -type f -name "SISRS*_align.fa" -printf "%f\n" | sed 's/\.[^.]*$//'| sed 's/_align//' > "${OUTFOLDER}"/loci/lostLoci/lociLostWithEmptyTaxa.txt #Create list of loci lost due to empty taxa > missing
-    find "${OUTFOLDER}"/loci/rawAlignmentsWithEmptyTaxa -maxdepth 1 -type f -name "SISRS*RawWithEmptySeqs.fa" -printf "%f\n" | sed 's/\.[^.]*$//' | sed 's/_align_RawWithEmptySeqs//' > "${OUTFOLDER}"/loci/rawAlignmentsWithEmptyTaxa/lociWithEmptyTaxaRemoved.txt #Create list of loci where empty taxa (< missing) were removed 
+    find "${OUTFOLDER}"/loci/rawAlignmentsWithEmptyTaxa -maxdepth 1 -type f -name "SISRS*RawWithEmptySeqs.fa" -printf "%f\n" | sed 's/\.[^.]*$//' | sed 's/_align_RawWithEmptySeqs//' > "${OUTFOLDER}"/loci/rawAlignmentsWithEmptyTaxa/lociWithEmptyTaxaRemoved.txt #Create list of loci where empty taxa (< missing) were removed
 }
 
 gfr_selectLoci_MV(){

--- a/bin/sisrs
+++ b/bin/sisrs
@@ -83,8 +83,8 @@ Option Flags:
       and must be called 'contigs.fa'
  -s : Sites to analyze when running 'loci' [0,1,2]
       0 [Default], all variable sites, including singletons
-      1, variable sites excluding singletons
-      2, only biallelic variable sites
+      1, variable sites, excluding singletons
+      2, only biallelic variable sites, excluding singletons
  -c : continous command mode for calling subcommands [1,0]
       1 [Default], calling a subcommand runs that subcommand and all subsequent
       steps in the pipeline
@@ -478,6 +478,7 @@ runSISRS(){
         i=0
     fi
     if [[ ${SUBCOMMAND} == 1 ]]; then
+      echo ===Running Subcommand $(echo ${cmds[$i]}) and Subsequent Subcommands===
       for (( i = $i; i < ${#cmds[@]}; i++ )); do      #run from selected opt to end
         ${cmds[$i]}
       done

--- a/libexec/sisrs/filter_nexus_for_missing.py
+++ b/libexec/sisrs/filter_nexus_for_missing.py
@@ -54,4 +54,4 @@ locfile.write("\n".join(newlocs))
 locfile.close()
 origLength = len(data[species[0]])
 newLength = len(newlocs)
-print 'With '+str(missing)+' taxa allowed to be missing, '+str(origLength)+' sites from '+path.basename(sys.argv[1])+' ('+str(len(species)-2)+' allowed missing) are reduced to '+str(len(newlocs))+' sites ('+str(origLength-newLength)+' sites or '+str('%.2f' % ((origLength-newLength/origLength)*100))+'% lost)'
+print 'With '+str(missing)+' taxa allowed to be missing, '+str(origLength)+' sites from '+path.basename(sys.argv[1])+' ('+str(len(species)-2)+' allowed missing) are reduced to '+str(len(newlocs))+' sites ('+str(origLength-newLength)+' sites or '+str('%.2f' % (((origLength-newLength)/origLength)*100))+'% lost)'

--- a/libexec/sisrs/filter_nexus_for_missing.py
+++ b/libexec/sisrs/filter_nexus_for_missing.py
@@ -51,4 +51,4 @@ SeqIO.write(datalist, path.dirname(sys.argv[1])+'/'+path.basename(sys.argv[1]).s
 locfile = open(path.dirname(sys.argv[1])+'/locs_m'+sys.argv[2]+'.txt', 'w')
 locfile.write("\n".join(newlocs))
 locfile.close()
-print 'With '+str(missing)+' taxa allowed to be missing, sites from '+path.basename(sys.argv[1]).split('.')[0]+' '+len(locs)+'  are reduced to '+len(newlocs)
+print 'With '+str(missing)+' taxa allowed to be missing, sites from '+path.basename(sys.argv[1]).split('.')[0]+' '+str(len(locs))+'  are reduced to '+str(len(newlocs))

--- a/libexec/sisrs/filter_nexus_for_missing.py
+++ b/libexec/sisrs/filter_nexus_for_missing.py
@@ -51,4 +51,4 @@ SeqIO.write(datalist, path.dirname(sys.argv[1])+'/'+path.basename(sys.argv[1]).s
 locfile = open(path.dirname(sys.argv[1])+'/locs_m'+sys.argv[2]+'.txt', 'w')
 locfile.write("\n".join(newlocs))
 locfile.close()
-print 'With '+str(missing)+' taxa allowed to be missing, sites from '+path.basename(sys.argv[1])+' '+str(len(locs))+' are reduced to '+str(len(newlocs))
+print 'With '+str(missing)+' taxa allowed to be missing, '+str(len(locs))+' sites from '+path.basename(sys.argv[1])+' ('+str(len(species)-2)+' allowed missing) are reduced to '+str(len(newlocs))+' sites'

--- a/libexec/sisrs/filter_nexus_for_missing.py
+++ b/libexec/sisrs/filter_nexus_for_missing.py
@@ -52,4 +52,4 @@ locfile = open(path.dirname(sys.argv[1])+'/locs_m'+sys.argv[2]+'.txt', 'w')
 locfile.write("\n".join(newlocs))
 locfile.close()
 loss = "%.2f" % ((len(locs)-len(newlocs))/(len(locs)))
-print 'With '+str(missing)+' taxa allowed to be missing, '+str(len(locs))+' sites from '+path.basename(sys.argv[1])+' ('+str(len(species)-2)+' allowed missing) are reduced to '+str(len(newlocs))+' sites ('+loss+'% of sites lost)'
+print 'With '+str(missing)+' taxa allowed to be missing, '+str(len(locs))+' sites from '+path.basename(sys.argv[1])+' ('+str(len(species)-2)+' allowed missing) are reduced to '+str(len(newlocs))+' sites ('+str(loss)+'% of sites lost)'

--- a/libexec/sisrs/filter_nexus_for_missing.py
+++ b/libexec/sisrs/filter_nexus_for_missing.py
@@ -51,5 +51,5 @@ SeqIO.write(datalist, path.dirname(sys.argv[1])+'/'+path.basename(sys.argv[1]).s
 locfile = open(path.dirname(sys.argv[1])+'/locs_m'+sys.argv[2]+'.txt', 'w')
 locfile.write("\n".join(newlocs))
 locfile.close()
-loss = "%.2f" % ((len(locs)-len(newlocs))/(len(locs)))*100
+loss = "%.2f" % (((len(locs)-len(newlocs))/(len(locs)))*100)
 print 'With '+str(missing)+' taxa allowed to be missing, '+str(len(locs))+' sites from '+path.basename(sys.argv[1])+' ('+str(len(species)-2)+' allowed missing) are reduced to '+str(len(newlocs))+' sites ('+str(loss)+'% of sites lost)'

--- a/libexec/sisrs/filter_nexus_for_missing.py
+++ b/libexec/sisrs/filter_nexus_for_missing.py
@@ -51,5 +51,5 @@ SeqIO.write(datalist, path.dirname(sys.argv[1])+'/'+path.basename(sys.argv[1]).s
 locfile = open(path.dirname(sys.argv[1])+'/locs_m'+sys.argv[2]+'.txt', 'w')
 locfile.write("\n".join(newlocs))
 locfile.close()
-loss = "%.2f" % ((len(locs)-len(newlocs))/(len(locs)))
+loss = "%.2f" % ((len(locs)-len(newlocs))/(len(locs)))*100
 print 'With '+str(missing)+' taxa allowed to be missing, '+str(len(locs))+' sites from '+path.basename(sys.argv[1])+' ('+str(len(species)-2)+' allowed missing) are reduced to '+str(len(newlocs))+' sites ('+str(loss)+'% of sites lost)'

--- a/libexec/sisrs/filter_nexus_for_missing.py
+++ b/libexec/sisrs/filter_nexus_for_missing.py
@@ -51,5 +51,7 @@ SeqIO.write(datalist, path.dirname(sys.argv[1])+'/'+path.basename(sys.argv[1]).s
 locfile = open(path.dirname(sys.argv[1])+'/locs_m'+sys.argv[2]+'.txt', 'w')
 locfile.write("\n".join(newlocs))
 locfile.close()
-loss = (((len(locs)-len(newlocs))/(len(locs)))*100)
+origLength = int(len(locs))
+newLength = int(len(newlocs))
+loss = float((origLength-newLength)/origLength)
 print 'With '+str(missing)+' taxa allowed to be missing, '+str(len(locs))+' sites from '+path.basename(sys.argv[1])+' ('+str(len(species)-2)+' allowed missing) are reduced to '+str(len(newlocs))+' sites ('+str('%.2f' % loss)+'% of sites lost)'

--- a/libexec/sisrs/filter_nexus_for_missing.py
+++ b/libexec/sisrs/filter_nexus_for_missing.py
@@ -53,5 +53,8 @@ locfile.write("\n".join(newlocs))
 locfile.close()
 origLength = int(len(locs))
 newLength = int(len(newlocs))
+print 'origLength'+str(origLength)
+print 'newLength'+str(newLength)
 loss = float((origLength-newLength)/origLength)
+print loss
 print 'With '+str(missing)+' taxa allowed to be missing, '+str(len(locs))+' sites from '+path.basename(sys.argv[1])+' ('+str(len(species)-2)+' allowed missing) are reduced to '+str(len(newlocs))+' sites ('+str('%.2f' % loss)+'% of sites lost)'

--- a/libexec/sisrs/filter_nexus_for_missing.py
+++ b/libexec/sisrs/filter_nexus_for_missing.py
@@ -10,6 +10,7 @@
     phylip formatted file ending with _mX.phylip-relaxed where X is the number missing
     """
 
+from __future__ import division
 import sys
 from os import path
 import linecache
@@ -18,7 +19,6 @@ from Bio.SeqRecord import SeqRecord
 from Bio.Alphabet import generic_dna, IUPAC, Gapped
 from Bio.Align import MultipleSeqAlignment, AlignInfo
 from Bio import AlignIO, SeqIO
-from __future__ import division
 
 ######################
 bases = ['A', 'C', 'G', 'T', 'a', 'c', 'g', 't','-']

--- a/libexec/sisrs/filter_nexus_for_missing.py
+++ b/libexec/sisrs/filter_nexus_for_missing.py
@@ -51,4 +51,4 @@ SeqIO.write(datalist, path.dirname(sys.argv[1])+'/'+path.basename(sys.argv[1]).s
 locfile = open(path.dirname(sys.argv[1])+'/locs_m'+sys.argv[2]+'.txt', 'w')
 locfile.write("\n".join(newlocs))
 locfile.close()
-print 'With '+str(missing)+' taxa allowed to be missing, sites from '+path.basename(sys.argv[1]).split('.')[0]+' '+str(len(locs))+'  are reduced to '+str(len(newlocs))
+print 'With '+str(missing)+' taxa allowed to be missing, sites from '+path.basename(sys.argv[1])+' '+str(len(locs))+' are reduced to '+str(len(newlocs))

--- a/libexec/sisrs/filter_nexus_for_missing.py
+++ b/libexec/sisrs/filter_nexus_for_missing.py
@@ -51,5 +51,5 @@ SeqIO.write(datalist, path.dirname(sys.argv[1])+'/'+path.basename(sys.argv[1]).s
 locfile = open(path.dirname(sys.argv[1])+'/locs_m'+sys.argv[2]+'.txt', 'w')
 locfile.write("\n".join(newlocs))
 locfile.close()
-loss = "%.2f" % (((len(locs)-len(newlocs))/(len(locs)))*100)
+loss = (((len(locs)-len(newlocs))/(len(locs)))*100)
 print 'With '+str(missing)+' taxa allowed to be missing, '+str(len(locs))+' sites from '+path.basename(sys.argv[1])+' ('+str(len(species)-2)+' allowed missing) are reduced to '+str(len(newlocs))+' sites ('+str(loss)+'% of sites lost)'

--- a/libexec/sisrs/filter_nexus_for_missing.py
+++ b/libexec/sisrs/filter_nexus_for_missing.py
@@ -51,3 +51,4 @@ SeqIO.write(datalist, path.dirname(sys.argv[1])+'/'+path.basename(sys.argv[1]).s
 locfile = open(path.dirname(sys.argv[1])+'/locs_m'+sys.argv[2]+'.txt', 'w')
 locfile.write("\n".join(newlocs))
 locfile.close()
+print 'With '+str(missing)+' taxa allowed to be missing, sites from '+path.basename(sys.argv[1]).split('.')[0]+' '+len(locs)+'  are reduced to '+len(newlocs)

--- a/libexec/sisrs/filter_nexus_for_missing.py
+++ b/libexec/sisrs/filter_nexus_for_missing.py
@@ -18,6 +18,7 @@ from Bio.SeqRecord import SeqRecord
 from Bio.Alphabet import generic_dna, IUPAC, Gapped
 from Bio.Align import MultipleSeqAlignment, AlignInfo
 from Bio import AlignIO, SeqIO
+from __future__ import division
 
 ######################
 bases = ['A', 'C', 'G', 'T', 'a', 'c', 'g', 't','-']
@@ -51,10 +52,5 @@ SeqIO.write(datalist, path.dirname(sys.argv[1])+'/'+path.basename(sys.argv[1]).s
 locfile = open(path.dirname(sys.argv[1])+'/locs_m'+sys.argv[2]+'.txt', 'w')
 locfile.write("\n".join(newlocs))
 locfile.close()
-origLength = int(len(locs))
-newLength = int(len(newlocs))
-print 'origLength'+str(origLength)
-print 'newLength'+str(newLength)
-loss = float((origLength-newLength)/origLength)
-print loss
+loss = ((len(locs)-len(newlocs))/len(locs))*100
 print 'With '+str(missing)+' taxa allowed to be missing, '+str(len(locs))+' sites from '+path.basename(sys.argv[1])+' ('+str(len(species)-2)+' allowed missing) are reduced to '+str(len(newlocs))+' sites ('+str('%.2f' % loss)+'% of sites lost)'

--- a/libexec/sisrs/filter_nexus_for_missing.py
+++ b/libexec/sisrs/filter_nexus_for_missing.py
@@ -54,4 +54,4 @@ locfile.write("\n".join(newlocs))
 locfile.close()
 origLength = len(data[species[0]])
 newLength = len(newlocs)
-print 'With '+str(missing)+' taxa allowed to be missing, '+str(origLength)+' sites from '+path.basename(sys.argv[1])+' ('+str(len(species)-2)+' allowed missing) are reduced to '+str(len(newlocs))+' sites ('+(len(data[species[0]]))-len(newlocs)+' sites or '+str('%.2f' % ((len(data[species[0]]))-len(newlocs)/(len(data[species[0]]))))+'% lost)'
+print 'With '+str(missing)+' taxa allowed to be missing, '+str(origLength)+' sites from '+path.basename(sys.argv[1])+' ('+str(len(species)-2)+' allowed missing) are reduced to '+str(len(newlocs))+' sites ('+str(origLength-newLength)+' sites or '+str('%.2f' % ((origLength-newLength/origLength)*100))+'% lost)'

--- a/libexec/sisrs/filter_nexus_for_missing.py
+++ b/libexec/sisrs/filter_nexus_for_missing.py
@@ -52,5 +52,5 @@ SeqIO.write(datalist, path.dirname(sys.argv[1])+'/'+path.basename(sys.argv[1]).s
 locfile = open(path.dirname(sys.argv[1])+'/locs_m'+sys.argv[2]+'.txt', 'w')
 locfile.write("\n".join(newlocs))
 locfile.close()
-loss = ((len(locs)-len(newlocs))/len(locs))*100
-print 'With '+str(missing)+' taxa allowed to be missing, '+str(len(locs))+' sites from '+path.basename(sys.argv[1])+' ('+str(len(species)-2)+' allowed missing) are reduced to '+str(len(newlocs))+' sites ('+str('%.2f' % loss)+'% of sites lost)'
+loss = (((len(locs)-2)-len(newlocs))/(len(locs)-2)*100
+print 'With '+str(missing)+' taxa allowed to be missing, '+str(len(locs)-2)+' sites from '+path.basename(sys.argv[1])+' ('+str(len(species)-2)+' allowed missing) are reduced to '+str(len(newlocs))+' sites ('+(len(locs)-2)-len(newlocs)+' sites or '+str('%.2f' % loss)+'% lost)'

--- a/libexec/sisrs/filter_nexus_for_missing.py
+++ b/libexec/sisrs/filter_nexus_for_missing.py
@@ -52,5 +52,6 @@ SeqIO.write(datalist, path.dirname(sys.argv[1])+'/'+path.basename(sys.argv[1]).s
 locfile = open(path.dirname(sys.argv[1])+'/locs_m'+sys.argv[2]+'.txt', 'w')
 locfile.write("\n".join(newlocs))
 locfile.close()
-loss = (((len(locs)-2)-len(newlocs))/(len(locs)-2)*100
-print 'With '+str(missing)+' taxa allowed to be missing, '+str(len(locs)-2)+' sites from '+path.basename(sys.argv[1])+' ('+str(len(species)-2)+' allowed missing) are reduced to '+str(len(newlocs))+' sites ('+(len(locs)-2)-len(newlocs)+' sites or '+str('%.2f' % loss)+'% lost)'
+origLength = len(data[species[0]])
+newLength = len(newlocs)
+print 'With '+str(missing)+' taxa allowed to be missing, '+str(origLength)+' sites from '+path.basename(sys.argv[1])+' ('+str(len(species)-2)+' allowed missing) are reduced to '+str(len(newlocs))+' sites ('+(len(data[species[0]]))-len(newlocs)+' sites or '+str('%.2f' % ((len(data[species[0]]))-len(newlocs)/(len(data[species[0]]))))+'% lost)'

--- a/libexec/sisrs/filter_nexus_for_missing.py
+++ b/libexec/sisrs/filter_nexus_for_missing.py
@@ -51,4 +51,5 @@ SeqIO.write(datalist, path.dirname(sys.argv[1])+'/'+path.basename(sys.argv[1]).s
 locfile = open(path.dirname(sys.argv[1])+'/locs_m'+sys.argv[2]+'.txt', 'w')
 locfile.write("\n".join(newlocs))
 locfile.close()
-print 'With '+str(missing)+' taxa allowed to be missing, '+str(len(locs))+' sites from '+path.basename(sys.argv[1])+' ('+str(len(species)-2)+' allowed missing) are reduced to '+str(len(newlocs))+' sites'
+loss = "%.2f" % ((len(locs)-len(newlocs))/(len(locs)))
+print 'With '+str(missing)+' taxa allowed to be missing, '+str(len(locs))+' sites from '+path.basename(sys.argv[1])+' ('+str(len(species)-2)+' allowed missing) are reduced to '+str(len(newlocs))+' sites ('+loss+'% of sites lost)'

--- a/libexec/sisrs/filter_nexus_for_missing.py
+++ b/libexec/sisrs/filter_nexus_for_missing.py
@@ -52,4 +52,4 @@ locfile = open(path.dirname(sys.argv[1])+'/locs_m'+sys.argv[2]+'.txt', 'w')
 locfile.write("\n".join(newlocs))
 locfile.close()
 loss = (((len(locs)-len(newlocs))/(len(locs)))*100)
-print 'With '+str(missing)+' taxa allowed to be missing, '+str(len(locs))+' sites from '+path.basename(sys.argv[1])+' ('+str(len(species)-2)+' allowed missing) are reduced to '+str(len(newlocs))+' sites ('+str(loss)+'% of sites lost)'
+print 'With '+str(missing)+' taxa allowed to be missing, '+str(len(locs))+' sites from '+path.basename(sys.argv[1])+' ('+str(len(species)-2)+' allowed missing) are reduced to '+str(len(newlocs))+' sites ('+str('%.2f' % loss)+'% of sites lost)'

--- a/libexec/sisrs/get_alignment.py
+++ b/libexec/sisrs/get_alignment.py
@@ -241,13 +241,13 @@ def write_alignment(fi,alignment,numbi):
         ALIGNMENT.write(species+"\t"+"".join(alignment.species_data[species])+"\n")
 
 
-    bi_ref_loc = [alignment.ref_loc[i] for i in range(len(alignment.locations)) if (alignment.flag[i] == 2 and alignment.single[i] == 0)]
-    bi_loc = [alignment.locations[i] for i in range(len(alignment.locations)) if (alignment.flag[i] == 2 and alignment.single[i] == 0)]
+    bi_ref_loc = [alignment.ref_loc[i] for i in range(len(alignment.locations)) if alignment.flag[i] == 2]
+    bi_loc = [alignment.locations[i] for i in range(len(alignment.locations)) if alignment.flag[i] == 2]
     bi_sp_data={}
     for species in spp:
-        bi_sp_data[species] = [alignment.species_data[species][i] for i in range(len(alignment.locations)) if (alignment.flag[i] == 2 and alignment.single[i] == 0)]
+        bi_sp_data[species] = [alignment.species_data[species][i] for i in range(len(alignment.locations)) if alignment.flag[i] == 2]
     if len(alignment.ref) > 0:
-        bi_sp_data['reference'] = [alignment.ref[i] for i in range(len(alignment.locations)) if (alignment.flag[i] == 2 and alignment.single[i] == 0)]
+        bi_sp_data['reference'] = [alignment.ref[i] for i in range(len(alignment.locations)) if alignment.flag[i] == 2]
 
     pi_ref_loc = [alignment.ref_loc[i] for i in range(len(alignment.locations)) if alignment.single[i] == 0]
     pi_loc = [alignment.locations[i] for i in range(len(alignment.locations)) if alignment.single[i] == 0]

--- a/libexec/sisrs/get_alignment.py
+++ b/libexec/sisrs/get_alignment.py
@@ -232,22 +232,25 @@ def write_alignment(fi,alignment,numbi):
     ALIGNMENTPI=open(fi.replace('.nex','_pi.nex'),'w')
 
     ALIGNMENT.write('#NEXUS\n\nBEGIN DATA;\nDIMENSIONS NTAX='+ntax+' NCHAR='+str(len(alignment.locations))+';\nFORMAT MISSING=? GAP=- DATATYPE=DNA;\nMATRIX\n')
-    ALIGNMENTBI.write('#NEXUS\n\nBEGIN DATA;\nDIMENSIONS NTAX='+ntax+' NCHAR='+str(numbi)+';\nFORMAT MISSING=? GAP=- DATATYPE=DNA;\nMATRIX\n')
-    ALIGNMENTPI.write('#NEXUS\n\nBEGIN DATA;\nDIMENSIONS NTAX='+ntax+' NCHAR='+str(alignment.single.count(0))+';\nFORMAT MISSING=? GAP=- DATATYPE=DNA;\nMATRIX\n')
-
     ALIGNMENT.write('[ '+ " ".join(alignment.ref_loc)+' ]'+"\n")
     ALIGNMENT.write('[ '+ " ".join(alignment.locations)+' ]'+"\n")
     for species in spp: #write sequences for each species
         ALIGNMENT.write(species+"\t"+"".join(alignment.species_data[species])+"\n")
 
 
-    bi_ref_loc = [alignment.ref_loc[i] for i in range(len(alignment.locations)) if alignment.flag[i] == 2]
-    bi_loc = [alignment.locations[i] for i in range(len(alignment.locations)) if alignment.flag[i] == 2]
+    bi_ref_loc = [alignment.ref_loc[i] for i in range(len(alignment.locations)) if alignment.flag[i] == 2 and alignment.single[i] == 0]
+    bi_loc = [alignment.locations[i] for i in range(len(alignment.locations)) if alignment.flag[i] == 2 and alignment.single[i] == 0]
     bi_sp_data={}
     for species in spp:
-        bi_sp_data[species] = [alignment.species_data[species][i] for i in range(len(alignment.locations)) if alignment.flag[i] == 2]
+        bi_sp_data[species] = [alignment.species_data[species][i] for i in range(len(alignment.locations)) if alignment.flag[i] == 2 and alignment.single[i] == 0]
     if len(alignment.ref) > 0:
-        bi_sp_data['reference'] = [alignment.ref[i] for i in range(len(alignment.locations)) if alignment.flag[i] == 2]
+        bi_sp_data['reference'] = [alignment.ref[i] for i in range(len(alignment.locations)) if alignment.flag[i] == 2 and alignment.single[i] == 0]
+
+    ALIGNMENTBI.write('#NEXUS\n\nBEGIN DATA;\nDIMENSIONS NTAX='+ntax+' NCHAR='+str(len(bi_loc))+';\nFORMAT MISSING=? GAP=- DATATYPE=DNA;\nMATRIX\n')
+    ALIGNMENTBI.write('[ '+ " ".join(bi_ref_loc)+' ]'+"\n")
+    ALIGNMENTBI.write('[ '+ " ".join(bi_loc)+' ]'+"\n")
+    for species in spp: #write sequences for each species
+        ALIGNMENTBI.write(species+"\t"+("".join(bi_sp_data[species]))+"\n")
 
     pi_ref_loc = [alignment.ref_loc[i] for i in range(len(alignment.locations)) if alignment.single[i] == 0]
     pi_loc = [alignment.locations[i] for i in range(len(alignment.locations)) if alignment.single[i] == 0]
@@ -257,11 +260,7 @@ def write_alignment(fi,alignment,numbi):
     if len(alignment.ref) > 0:
         pi_sp_data['reference'] = [alignment.ref[i] for i in range(len(alignment.locations)) if alignment.single[i] == 0]
 
-    ALIGNMENTBI.write('[ '+ " ".join(bi_ref_loc)+' ]'+"\n")
-    ALIGNMENTBI.write('[ '+ " ".join(bi_loc)+' ]'+"\n")
-    for species in spp: #write sequences for each species
-        ALIGNMENTBI.write(species+"\t"+("".join(bi_sp_data[species]))+"\n")
-
+    ALIGNMENTPI.write('#NEXUS\n\nBEGIN DATA;\nDIMENSIONS NTAX='+ntax+' NCHAR='+str(len(pi_loc))+';\nFORMAT MISSING=? GAP=- DATATYPE=DNA;\nMATRIX\n')
     ALIGNMENTPI.write('[ '+ " ".join(pi_ref_loc)+' ]'+"\n")
     ALIGNMENTPI.write('[ '+ " ".join(pi_loc)+' ]'+"\n")
     for species in spp: #write sequences for each species

--- a/libexec/sisrs/get_alignment.py
+++ b/libexec/sisrs/get_alignment.py
@@ -52,7 +52,7 @@ class Alignment:
         self.single = single
 
     def numsnps(self):
-        print str(len(self.locations))+' variable sites'
+        print str(len(self.locations))+' total variable sites'
         for i in range(len(self.locations)):
             bases = [self.species_data[sp][i] for sp in self.species_data if self.species_data[sp][i] in ['A','C','G','T','-']]     #bases for that site
             c = Counter(bases).most_common(5)
@@ -62,8 +62,7 @@ class Alignment:
                 self.single.append(0)
             self.flag.append(len(c))
 
-        print str(self.flag.count(2))+' biallelic sites'
-        print str(self.single.count(1))+' singletons'
+        print str(self.single.count(1))+' variable sites are singletons'
 
         return self.flag.count(2)       # number of biallelic sites
 
@@ -251,6 +250,7 @@ def write_alignment(fi,alignment,numbi):
     ALIGNMENTBI.write('[ '+ " ".join(bi_loc)+' ]'+"\n")
     for species in spp: #write sequences for each species
         ALIGNMENTBI.write(species+"\t"+("".join(bi_sp_data[species]))+"\n")
+    print str(len(bi_loc))+' total biallelic sites excluding singletons (alignment_bi.nex)'
 
     pi_ref_loc = [alignment.ref_loc[i] for i in range(len(alignment.locations)) if alignment.single[i] == 0]
     pi_loc = [alignment.locations[i] for i in range(len(alignment.locations)) if alignment.single[i] == 0]
@@ -265,6 +265,7 @@ def write_alignment(fi,alignment,numbi):
     ALIGNMENTPI.write('[ '+ " ".join(pi_loc)+' ]'+"\n")
     for species in spp: #write sequences for each species
         ALIGNMENTPI.write(species+"\t"+("".join(pi_sp_data[species]))+"\n")
+    print str(len(pi_loc))+' total variable sites excluding singletons (alignment_pi.nex)'
 
     if len(alignment.ref) > 0:
         ALIGNMENT.write('reference'+"\t"+("".join(alignment.ref))+"\n")

--- a/libexec/sisrs/get_alignment.py
+++ b/libexec/sisrs/get_alignment.py
@@ -52,7 +52,7 @@ class Alignment:
         self.single = single
 
     def numsnps(self):
-        print str(len(self.locations))+' total variable sites'
+        print str(len(self.locations))+' total variable sites (alignment.nex)'
         for i in range(len(self.locations)):
             bases = [self.species_data[sp][i] for sp in self.species_data if self.species_data[sp][i] in ['A','C','G','T','-']]     #bases for that site
             c = Counter(bases).most_common(5)

--- a/libexec/sisrs/get_alignment.py
+++ b/libexec/sisrs/get_alignment.py
@@ -241,13 +241,13 @@ def write_alignment(fi,alignment,numbi):
         ALIGNMENT.write(species+"\t"+"".join(alignment.species_data[species])+"\n")
 
 
-    bi_ref_loc = [alignment.ref_loc[i] for i in range(len(alignment.locations)) if alignment.flag[i] == 2 and alignment.single[i] == 0]
-    bi_loc = [alignment.locations[i] for i in range(len(alignment.locations)) if alignment.flag[i] == 2 and alignment.single[i] == 0]
+    bi_ref_loc = [alignment.ref_loc[i] for i in range(len(alignment.locations)) if (alignment.flag[i] == 2 and alignment.single[i] == 0)]
+    bi_loc = [alignment.locations[i] for i in range(len(alignment.locations)) if (alignment.flag[i] == 2 and alignment.single[i] == 0)]
     bi_sp_data={}
     for species in spp:
-        bi_sp_data[species] = [alignment.species_data[species][i] for i in range(len(alignment.locations)) if alignment.flag[i] == 2 and alignment.single[i] == 0]
+        bi_sp_data[species] = [alignment.species_data[species][i] for i in range(len(alignment.locations)) if (alignment.flag[i] == 2 and alignment.single[i] == 0)]
     if len(alignment.ref) > 0:
-        bi_sp_data['reference'] = [alignment.ref[i] for i in range(len(alignment.locations)) if alignment.flag[i] == 2 and alignment.single[i] == 0]
+        bi_sp_data['reference'] = [alignment.ref[i] for i in range(len(alignment.locations)) if (alignment.flag[i] == 2 and alignment.single[i] == 0)]
 
     pi_ref_loc = [alignment.ref_loc[i] for i in range(len(alignment.locations)) if alignment.single[i] == 0]
     pi_loc = [alignment.locations[i] for i in range(len(alignment.locations)) if alignment.single[i] == 0]

--- a/libexec/sisrs/get_alignment.py
+++ b/libexec/sisrs/get_alignment.py
@@ -241,13 +241,13 @@ def write_alignment(fi,alignment,numbi):
         ALIGNMENT.write(species+"\t"+"".join(alignment.species_data[species])+"\n")
 
 
-    bi_ref_loc = [alignment.ref_loc[i] for i in range(len(alignment.locations)) if alignment.flag[i] == 2]
-    bi_loc = [alignment.locations[i] for i in range(len(alignment.locations)) if alignment.flag[i] == 2]
+    bi_ref_loc = [alignment.ref_loc[i] for i in range(len(alignment.locations)) if alignment.flag[i] == 2 and alignment.single[i] == 0]
+    bi_loc = [alignment.locations[i] for i in range(len(alignment.locations)) if alignment.flag[i] == 2 and alignment.single[i] == 0]
     bi_sp_data={}
     for species in spp:
-        bi_sp_data[species] = [alignment.species_data[species][i] for i in range(len(alignment.locations)) if alignment.flag[i] == 2]
+        bi_sp_data[species] = [alignment.species_data[species][i] for i in range(len(alignment.locations)) if alignment.flag[i] == 2 and alignment.single[i] == 0]
     if len(alignment.ref) > 0:
-        bi_sp_data['reference'] = [alignment.ref[i] for i in range(len(alignment.locations)) if alignment.flag[i] == 2]
+        bi_sp_data['reference'] = [alignment.ref[i] for i in range(len(alignment.locations)) if alignment.flag[i] == 2 and alignment.single[i] == 0]
 
     pi_ref_loc = [alignment.ref_loc[i] for i in range(len(alignment.locations)) if alignment.single[i] == 0]
     pi_loc = [alignment.locations[i] for i in range(len(alignment.locations)) if alignment.single[i] == 0]


### PR DESCRIPTION
Previous (-s) option allowed for choice of Singletons vs. No Singletons. -s now has 3 options:

0 [Default]: All variable sites considered in 'loci' (alignment.nex)
1: No singletons (alignment_pi.nex)
2: Biallelic only (alignment_bi.nex)

changeMissing now partitions data subsets into separate folders (alignmentDataWithoutSingletons; alignmentDataWithOnlyBiallelic) and 'loci' will read from whichever dataset the user requests via -s. 